### PR TITLE
Fix missing closing bracket in integrations/class-woocommerce.php

### DIFF
--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -218,7 +218,7 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 		<p class="form-field affwp-woo-coupon-field">
 			<label for="user_name"><?php _e( 'Affiliate Discount?', 'affiliate-wp' ); ?></label>
 			<span class="affwp-ajax-search-wrap">
-				<span class="affwp-woo-coupon-input-wrap"
+				<span class="affwp-woo-coupon-input-wrap">
 					<input type="hidden" name="user_id" id="user_id" value="<?php echo esc_attr( $user_id ); ?>" />
 					<input type="text" name="user_name" id="user_name" value="<?php echo esc_attr( $user_name ); ?>" class="affwp-user-search" autocomplete="off" />
 					<img class="affwp-ajax waiting" src="<?php echo admin_url('images/wpspin_light.gif'); ?>" style="display: none;"/>


### PR DESCRIPTION
In e8c76ade0913ed8fa80775ac3c5fba546d468b95 a closing bracket was lost on the new span. This fixes the currently broken markup. 