### PR TITLE
Remove a variable that's no longer used

### DIFF
--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -74,7 +74,6 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 				return false; // Referral already created for this reference
 			}
 
-			$cart_discount = $this->order->get_total_discount();
 			$cart_shipping = $this->order->get_total_shipping();
 
 			$items = $this->order->get_items();


### PR DESCRIPTION
After 384353a0c786ac7b1f3d7121155e92ece5e41f5b the `$cart_discount` variable is no longer used anywhere in the function. 