### PR TITLE
Add hooks to creatives

### DIFF
--- a/templates/dashboard-tab-creatives.php
+++ b/templates/dashboard-tab-creatives.php
@@ -14,7 +14,7 @@
 
 	<?php if( $creatives ) : ?>
 	
-		<?php do_action( 'affwp-before-first-creative' ); ?>
+		<?php do_action( 'affwp_before_creatives' ); ?>
 
 		<?php echo affiliate_wp()->creative->affiliate_creatives( $args ); ?>
 
@@ -30,7 +30,7 @@
 			?>
 		</div>
 		
-		<?php do_action( 'affwp-after-last-creative' ); ?>
+		<?php do_action( 'affwp_after_creatives' ); ?>
 
 	<?php else : ?>
 		<p class="affwp-no-results"><?php _e( 'Sorry, there are currently no creatives available.', 'affiliate-wp' ); ?></p>

--- a/templates/dashboard-tab-creatives.php
+++ b/templates/dashboard-tab-creatives.php
@@ -13,6 +13,8 @@
 	?>
 
 	<?php if( $creatives ) : ?>
+	
+		<?php do_action( 'affwp-before-first-creative' ); ?>
 
 		<?php echo affiliate_wp()->creative->affiliate_creatives( $args ); ?>
 
@@ -27,6 +29,8 @@
 			) );
 			?>
 		</div>
+		
+		<?php do_action( 'affwp-after-last-creative' ); ?>
 
 	<?php else : ?>
 		<p class="affwp-no-results"><?php _e( 'Sorry, there are currently no creatives available.', 'affiliate-wp' ); ?></p>


### PR DESCRIPTION
Allow to add custom creatives, before or after the list

For example:

    // add video embed code to affiliatewp creatives
    function add_video_to_creatives() {
    ?>
      <div class="affwp-creative">
        <p>
          <!-- custom video code here -->
       </p>
       <p>Copy and paste the following:</p>
       <p>
           <!-- custom embed video code here -->
        </p>
      </div>
    <?php
    }
    add_action( 'affwp-before-first-creative', 'add_video_to_creatives' );

Already using it in my website and it's working great.