### PR TITLE
Integration hooks

### DIFF
--- a/includes/class-integrations.php
+++ b/includes/class-integrations.php
@@ -37,6 +37,8 @@ class Affiliate_WP_Integrations {
 
 		$enabled = apply_filters( 'affwp_enabled_integrations', $this->get_enabled_integrations() );
 
+		do_action( 'affiliate_wp_integrations_load' );
+
 		foreach( $enabled as $filename => $integration ) {
 
 			if( file_exists( AFFILIATEWP_PLUGIN_DIR . 'includes/integrations/class-' . $filename . '.php' ) ) {
@@ -44,6 +46,8 @@ class Affiliate_WP_Integrations {
 			}
 
 		}
+
+		do_action( 'affiliate_wp_integrations_loaded' );
 
 	}
 


### PR DESCRIPTION
actions aren't technically necessary but when I worked on my integration I was looking for an easy way to load up the Affiliate_WP_Base subclass at the ideal time, which I could not find. This is different than filtering the integrations via affwp_enabled_integrations becuase there's no way to have the loop load up the subclass since the file path is a constant (and defined).