### PR TITLE
register affiliatemeta table as early as possible

### DIFF
--- a/includes/class-affiliate-meta-db.php
+++ b/includes/class-affiliate-meta-db.php
@@ -20,7 +20,7 @@ class Affiliate_WP_Affiliate_Meta_DB extends Affiliate_WP_DB {
 		$this->primary_key = 'meta_id';
 		$this->version     = '1.0';
 
-		add_action( 'plugins_loaded', array( $this, 'register_table' ) );
+		add_action( 'plugins_loaded', array( $this, 'register_table' ), 11 );
 
 	}
 

--- a/includes/class-affiliate-meta-db.php
+++ b/includes/class-affiliate-meta-db.php
@@ -20,7 +20,7 @@ class Affiliate_WP_Affiliate_Meta_DB extends Affiliate_WP_DB {
 		$this->primary_key = 'meta_id';
 		$this->version     = '1.0';
 
-		add_action( 'init', array( $this, 'register_table' ) );
+		add_action( 'plugins_loaded', array( $this, 'register_table' ) );
 
 	}
 


### PR DESCRIPTION
Seems `init` is a bit late to register the affiliatemeta table with $wpdb, moving to `plugins_loaded` hook so that it's properly registered for (hopefully) all use cases. 

Had a function hooked into `affwp_post_update_affiliate` and when calling `affwp_update_affiliate_meta()` it was returning false because the table hadn't been registered for use. 