### PR TITLE
change did_action()

### DIFF
--- a/includes/class-register.php
+++ b/includes/class-register.php
@@ -243,7 +243,7 @@ class Affiliate_WP_Register {
 			return;
 		}
 
-		if ( did_action( 'process_registration' ) ) {
+		if ( did_action( 'affwp_affiliate_register' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #686 

@pippinsplugins look ok to you? Looks like it was using the function name, rather than the action hook name. Tested and both types of registration seem to work fine.