### PR TITLE
Add word-wrap CSS rule to tables

### DIFF
--- a/assets/css/forms.css
+++ b/assets/css/forms.css
@@ -186,3 +186,7 @@ p.affwp-error {
 	-ms-hyphens: none;
 	hyphens: none;
 }
+
+.affwp-table {
+	word-wrap: break-word;
+}


### PR DESCRIPTION
Fixes #669 

To try and simulate the issue on themes that don't have suitable styling I first removed 2015's default CSS for word-wrap which resulted in this:

![screen shot 2015-06-01 at 10 56 01 am](https://cloud.githubusercontent.com/assets/52581/7904405/12272312-084d-11e5-8ee7-7d1a69bafb35.png)

Then I added the new `word-wrap` CSS rule to our tables which gives us:

![screen shot 2015-06-01 at 10 56 13 am](https://cloud.githubusercontent.com/assets/52581/7904407/26f6f34e-084d-11e5-9e2d-81a1a21d5dcb.png)

It would be better if themes had this CSS rule on `.entry-content`, ie the wrapping content div but because themes can easily change this class it would be better if we applied it specifically to our tables.
