### PR TITLE
Remove the redirect from affwp_update_profile_settings()

### DIFF
--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -874,9 +874,7 @@ function affwp_update_profile_settings( $data = array() ) {
 
 	do_action( 'affwp_update_affiliate_profile_settings', $data );
 
-	if ( ! empty( $_POST['affwp_action'] ) ) {
-		wp_redirect( add_query_arg( 'affwp_notice', 'profile-updated' ) ); exit;
-	}
+	
 }
 
 /**


### PR DESCRIPTION
This redirect makes it impossible to process additional settings added by plugins.

I'm using the following action to add settings the user settings dashboard:  
add_action( 'affwp_affiliate_dashboard_before_submit', array( $this, 'front_end_settings_output' ), 10, 2 );

I can't find any way to process these settings due to the redirect.