### PR TITLE
Fix PMP Order ID & Reference Link

### DIFF
--- a/includes/integrations/class-pmp.php
+++ b/includes/integrations/class-pmp.php
@@ -6,7 +6,7 @@ class Affiliate_WP_PMP extends Affiliate_WP_Base {
 
 		$this->context = 'pmp';
 
-		add_action( 'pmpro_add_order', array( $this, 'add_pending_referral' ), 10 );
+		add_action( 'pmpro_added_order', array( $this, 'add_pending_referral' ), 10 );
 		add_action( 'pmpro_updated_order', array( $this, 'mark_referral_complete' ), 10 );
 		add_action( 'admin_init', array( $this, 'revoke_referral_on_refund_and_cancel' ), 10);
 		add_action( 'pmpro_delete_order', array( $this, 'revoke_referral_on_delete' ), 10, 2 );
@@ -23,9 +23,9 @@ class Affiliate_WP_PMP extends Affiliate_WP_Base {
 				return; // Customers cannot refer themselves
 			}
 
-			$referral_total = $this->calculate_referral_amount( $order->subtotal, $order->code );
+			$referral_total = $this->calculate_referral_amount( $order->subtotal, $order->id );
 
-			$referral_id = $this->insert_pending_referral( $referral_total, $order->code, $order->membership_name );
+			$referral_id = $this->insert_pending_referral( $referral_total, $order->id, $order->membership_name );
 
 			if( 'success' === strtolower( $order->status ) ) {
 
@@ -33,7 +33,7 @@ class Affiliate_WP_PMP extends Affiliate_WP_Base {
 					affiliate_wp()->referrals->update( $referral_id, array( 'custom' => $order->id ), '', 'referral' );
 				}
 
-				$this->complete_referral( $order->code );
+				$this->complete_referral( $order->id );
 
 			}
 		}
@@ -46,13 +46,7 @@ class Affiliate_WP_PMP extends Affiliate_WP_Base {
 			return;
 		}
 
-		// Now update the referral to have a nice reference. PMP doesn't make the order ID available early enough
-		$referral = affiliate_wp()->referrals->get_by( 'reference', $order->code );
-		if( $referral ) {
-			affiliate_wp()->referrals->update( $referral->referral_id, array( 'custom' => $order->id ), '', 'referral' );
-		}
-
-		$this->complete_referral( $order->code );
+		$this->complete_referral( $order->id );
 	}
 
 	public function revoke_referral_on_refund_and_cancel() {


### PR DESCRIPTION
This swaps the PMP Order Code with the Order ID, effectively linking the PMP Order to the Referral.