### PR TITLE
Fix expected number_format() values on manual referral insert

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -117,7 +117,7 @@ function affwp_sanitize_amount( $amount ) {
 	}
 
 	$decimals = apply_filters( 'affwp_sanitize_amount_decimals', 2, $amount );
-	$amount   = number_format( $amount, $decimals, '.', '' );
+	$amount   = number_format( floatval( $amount ), absint( $decimals ), '.', '' );
 
 	return apply_filters( 'affwp_sanitize_amount', $amount );
 }


### PR DESCRIPTION
Fixes #744 

Simple sanitization of the first param value fixes the issue described with the `number_format()` function during manual referral creation.

This PR also implements sanitization on the filtered `$decimal` value, though not described in the issue it will prevent problems down the road as that param should always be a absolute integer.

**Aside:** Should manual referrals even be allowed when the amount is $0.00? Maybe that's a bit out of scope for the issue at hand, but something to think about anyway.