### PR TITLE
Issue/665

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -76,35 +76,47 @@ jQuery(document).ready(function($) {
 		$('.affwp-datepicker').datepicker();
 	}
 
+	var user_search_delay;
+
 	// ajax user search
-	$('.affwp-user-search').keyup(function() {
-		var user_search = $(this).val();
-		$('.affwp-ajax').show();
-		data = {
-			action: 'affwp_search_users',
-			user_name: user_search
-		};
+	$('body').on( 'input', '.affwp-user-search', function() {
+		clearTimeout( user_search_delay );
 
-		$.ajax({
-			type: "POST",
-			data: data,
-			dataType: "json",
-			url: ajaxurl,
-			success: function (search_response) {
+		$('.affwp-ajax').hide();
 
-				$('.affwp-ajax').hide();
+		var user_search = $(this).val(), status = $(this).data('affwp-status');
 
-				$('#affwp_user_search_results').html('');
+		// delay search 500ms between keypress for performance
+		user_search_delay = setTimeout( function() {
+			$('.affwp-ajax').show();
 
-				$(search_response.results).appendTo('#affwp_user_search_results');
+			data = {
+				action: 'affwp_search_users',
+				search: user_search,
+				status: status
+			};
 
-				if( $('.affwp-woo-coupon-field').length ) {
-					var height = $('.affwp-woo-coupon-field #affwp_user_search_results' ).height();
-					$('.affwp-woo-coupon-field #affwp_user_search_results').css('top', '-' + height + 'px' );
+			$.ajax({
+				type: "POST",
+				data: data,
+				dataType: "json",
+				url: ajaxurl,
+				success: function (search_response) {
+					$('.affwp-ajax').hide();
+
+					$('#affwp_user_search_results').html('');
+
+					$(search_response.results).appendTo('#affwp_user_search_results');
+
+					if( $('.affwp-woo-coupon-field').length ) {
+						var height = $('.affwp-woo-coupon-field #affwp_user_search_results' ).height();
+						$('.affwp-woo-coupon-field #affwp_user_search_results').css('top', '-' + height + 'px' );
+					}
 				}
-			}
-		});
+			});
+		}, 500);
 	});
+
 	$('body').on('click.rcpSelectUser', '#affwp_user_search_results a', function(e) {
 		e.preventDefault();
 		var login = $(this).data('login'), id = $(this).data('id');

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -79,7 +79,7 @@ jQuery(document).ready(function($) {
 	var user_search_delay;
 
 	// ajax user search
-	$('body').on( 'input', '.affwp-user-search', function() {
+	$('body').on( 'input change', '.affwp-user-search', function() {
 		clearTimeout( user_search_delay );
 
 		$('.affwp-ajax').hide();

--- a/includes/admin/affiliates/new.php
+++ b/includes/admin/affiliates/new.php
@@ -18,7 +18,7 @@
 
 				<td>
 					<span class="affwp-ajax-search-wrap">
-						<input type="text" name="user_name" id="user_name" class="affwp-user-search" autocomplete="off" />
+						<input type="text" name="user_name" id="user_name" class="affwp-user-search" data-affwp-status="false" autocomplete="off" />
 						<img class="affwp-ajax waiting" src="<?php echo admin_url('images/wpspin_light.gif'); ?>" style="display: none;"/>
 					</span>
 					<div id="affwp_user_search_results"></div>

--- a/includes/admin/affiliates/new.php
+++ b/includes/admin/affiliates/new.php
@@ -1,7 +1,7 @@
 <div class="wrap">
 
 	<h2><?php _e( 'New Affiliate', 'affiliate-wp' ); ?></h2>
-	
+
 	<form method="post" id="affwp_add_affiliate">
 
 		<?php do_action( 'affwp_new_affiliate_top' ); ?>
@@ -18,7 +18,7 @@
 
 				<td>
 					<span class="affwp-ajax-search-wrap">
-						<input type="text" name="user_name" id="user_name" class="affwp-user-search" data-affwp-status="false" autocomplete="off" />
+						<input type="text" name="user_name" id="user_name" class="affwp-user-search" data-affwp-status="none" autocomplete="off" />
 						<img class="affwp-ajax waiting" src="<?php echo admin_url('images/wpspin_light.gif'); ?>" style="display: none;"/>
 					</span>
 					<div id="affwp_user_search_results"></div>

--- a/includes/admin/ajax-actions.php
+++ b/includes/admin/ajax-actions.php
@@ -3,33 +3,81 @@
 // retrieves a list of users via live search
 function affwp_search_users() {
 
-	if( empty( $_POST['user_name'] ) ) {
+	if ( empty( $_POST['search'] ) ) {
 		die( '-1' );
 	}
 
-	if( ! current_user_can( 'manage_affiliates' ) ) {
+	if ( ! current_user_can( 'manage_affiliates' ) ) {
 		die( '-1' );
 	}
 
-	$search_query = htmlentities2( trim( $_POST['user_name'] ) );
+	$search_query = htmlentities2( trim( $_POST['search'] ) );
 
 	do_action( 'affwp_pre_search_users', $search_query );
 
-	$found_users = get_users( array(
-			'number' => 9999,
-			'search' => $search_query . '*'
-		)
+	$args = array();
+
+	if ( isset( $_POST['status'] ) ) {
+		$status = mb_strtolower( htmlentities2( trim( $_POST['status'] ) ) );
+
+		switch ( $status ) {
+			case 'false':
+				$affiliates = affiliate_wp()->affiliates->get_affiliates(
+					array(
+						'number' => 9999,
+					)
+				);
+				$args = array( 'exclude' => wp_list_pluck( $affiliates, 'affiliate_id' ) );
+				break;
+			case 'any':
+				$affiliates = affiliate_wp()->affiliates->get_affiliates(
+					array(
+						'number' => 9999,
+					)
+				);
+				$args = array( 'include' => wp_list_pluck( $affiliates, 'affiliate_id' ) );
+				break;
+			default:
+				$affiliates = affiliate_wp()->affiliates->get_affiliates(
+					array(
+						'number' => 9999,
+						'status' => $status,
+					)
+				);
+				$args = array( 'include' => wp_list_pluck( $affiliates, 'affiliate_id' ) );
+		}
+	}
+
+	$found_users = array_filter(
+		get_users( $args ),
+		function ( $user ) {
+			$q = mb_strtolower( htmlentities2( trim( $_POST['search'] ) ) );
+
+			$user_login   = mb_strtolower( $user->user_login );
+			$display_name = mb_strtolower( $user->display_name );
+			$user_email   = mb_strtolower( $user->user_email );
+
+			// Detect query term matches from these user fields (in order of priority)
+			return (
+				false !== mb_strpos( $user_login, $q )
+				||
+				false !== mb_strpos( $display_name, $q )
+				||
+				false !== mb_strpos( $user_email, $q )
+			);
+		}
 	);
 
-	if( $found_users ) {
+	if ( $found_users ) {
 		$user_list = '<ul>';
+
 		foreach( $found_users as $user ) {
 			$user_list .= '<li><a href="#" data-id="' . esc_attr( $user->ID ) . '" data-login="' . esc_attr( $user->user_login ) . '">' . esc_html( $user->user_login ) . '</a></li>';
 		}
+
 		$user_list .= '</ul>';
 
 		echo json_encode( array( 'results' => $user_list, 'id' => 'found' ) );
-
 	} else {
 		echo json_encode( array( 'results' => '<p>' . __( 'No users found', 'affiliate-wp' ) . '</p>', 'id' => 'fail' ) );
 	}

--- a/includes/admin/ajax-actions.php
+++ b/includes/admin/ajax-actions.php
@@ -27,7 +27,7 @@ function affwp_search_users() {
 						'number' => 9999,
 					)
 				);
-				$args = array( 'exclude' => array_map( 'absint', wp_list_pluck( $affiliates, 'affiliate_id' ) ) );
+				$args = array( 'exclude' => array_map( 'absint', wp_list_pluck( $affiliates, 'user_id' ) ) );
 				break;
 			case 'any':
 				$affiliates = affiliate_wp()->affiliates->get_affiliates(
@@ -35,7 +35,7 @@ function affwp_search_users() {
 						'number' => 9999,
 					)
 				);
-				$args = array( 'include' => array_map( 'absint', wp_list_pluck( $affiliates, 'affiliate_id' ) ) );
+				$args = array( 'include' => array_map( 'absint', wp_list_pluck( $affiliates, 'user_id' ) ) );
 				break;
 			default:
 				$affiliates = affiliate_wp()->affiliates->get_affiliates(
@@ -44,7 +44,7 @@ function affwp_search_users() {
 						'status' => $status,
 					)
 				);
-				$args = array( 'include' => array_map( 'absint', wp_list_pluck( $affiliates, 'affiliate_id' ) ) );
+				$args = array( 'include' => array_map( 'absint', wp_list_pluck( $affiliates, 'user_id' ) ) );
 		}
 	}
 

--- a/includes/admin/ajax-actions.php
+++ b/includes/admin/ajax-actions.php
@@ -27,7 +27,7 @@ function affwp_search_users() {
 						'number' => 9999,
 					)
 				);
-				$args = array( 'exclude' => wp_list_pluck( $affiliates, 'affiliate_id' ) );
+				$args = array( 'exclude' => array_map( 'absint', wp_list_pluck( $affiliates, 'affiliate_id' ) ) );
 				break;
 			case 'any':
 				$affiliates = affiliate_wp()->affiliates->get_affiliates(
@@ -35,7 +35,7 @@ function affwp_search_users() {
 						'number' => 9999,
 					)
 				);
-				$args = array( 'include' => wp_list_pluck( $affiliates, 'affiliate_id' ) );
+				$args = array( 'include' => array_map( 'absint', wp_list_pluck( $affiliates, 'affiliate_id' ) ) );
 				break;
 			default:
 				$affiliates = affiliate_wp()->affiliates->get_affiliates(
@@ -44,7 +44,7 @@ function affwp_search_users() {
 						'status' => $status,
 					)
 				);
-				$args = array( 'include' => wp_list_pluck( $affiliates, 'affiliate_id' ) );
+				$args = array( 'include' => array_map( 'absint', wp_list_pluck( $affiliates, 'affiliate_id' ) ) );
 		}
 	}
 

--- a/includes/admin/ajax-actions.php
+++ b/includes/admin/ajax-actions.php
@@ -21,7 +21,7 @@ function affwp_search_users() {
 		$status = mb_strtolower( htmlentities2( trim( $_POST['status'] ) ) );
 
 		switch ( $status ) {
-			case 'false':
+			case 'none':
 				$affiliates = affiliate_wp()->affiliates->get_affiliates(
 					array(
 						'number' => 9999,

--- a/includes/admin/referrals/new.php
+++ b/includes/admin/referrals/new.php
@@ -18,7 +18,7 @@
 
 				<td>
 					<span class="affwp-ajax-search-wrap">
-						<input type="text" name="user_name" id="user_name" class="affwp-user-search" autocomplete="off" />
+						<input type="text" name="user_name" id="user_name" class="affwp-user-search" data-affwp-status="active" autocomplete="off" />
 						<img class="affwp-ajax waiting" src="<?php echo admin_url('images/wpspin_light.gif'); ?>" style="display: none;"/>
 					</span>
 					<div id="affwp_user_search_results"></div>

--- a/includes/admin/visits/visits.php
+++ b/includes/admin/visits/visits.php
@@ -29,7 +29,7 @@ function affwp_visits_admin() {
 		<form id="affwp-visits-filter" method="get" action="<?php echo admin_url( 'admin.php?page=affiliate-wp' ); ?>">
 			<?php $visits_table->search_box( __( 'Search', 'affiliate-wp' ), 'affwp-affiliates' ); ?>
 			<span class="affwp-ajax-search-wrap">
-				<input type="text" name="user_name" id="user_name" class="affwp-user-search" autocomplete="off" placeholder="<?php _e( 'Affiliate name', 'affiliate-wp' ); ?>" />
+				<input type="text" name="user_name" id="user_name" class="affwp-user-search" data-affwp-status="any" autocomplete="off" placeholder="<?php _e( 'Affiliate name', 'affiliate-wp' ); ?>" />
 				<img class="affwp-ajax waiting" src="<?php echo admin_url('images/wpspin_light.gif'); ?>" style="display: none;"/>
 			</span>
 			<div id="affwp_user_search_results"></div>

--- a/includes/integrations/class-edd.php
+++ b/includes/integrations/class-edd.php
@@ -403,7 +403,7 @@ class Affiliate_WP_EDD extends Affiliate_WP_Base {
 					<td>
 						<span class="affwp-ajax-search-wrap">
 							<input type="hidden" name="user_id" id="user_id" value="<?php echo esc_attr( $user_id ); ?>" />
-							<input type="text" name="user_name" id="user_name" value="<?php echo esc_attr( $user_name ); ?>" class="affwp-user-search" autocomplete="off" style="width: 300px;" />
+							<input type="text" name="user_name" id="user_name" value="<?php echo esc_attr( $user_name ); ?>" class="affwp-user-search" data-affwp-status="active" autocomplete="off" style="width: 300px;" />
 							<img class="affwp-ajax waiting" src="<?php echo admin_url('images/wpspin_light.gif'); ?>" style="display: none;"/>
 						</span>
 						<div id="affwp_user_search_results"></div>

--- a/includes/integrations/class-exchange.php
+++ b/includes/integrations/class-exchange.php
@@ -236,7 +236,7 @@ class Affiliate_WP_Exchange extends Affiliate_WP_Base {
 			<td>
 				<span class="affwp-ajax-search-wrap">
 					<input type="hidden" name="user_id" id="user_id" value="<?php echo esc_attr( $user_id ); ?>" />
-					<input type="text" name="user_name" id="user_name" value="<?php echo esc_attr( $user_name ); ?>" class="affwp-user-search" autocomplete="off" />
+					<input type="text" name="user_name" id="user_name" value="<?php echo esc_attr( $user_name ); ?>" class="affwp-user-search" data-affwp-status="active" autocomplete="off" />
 					<img class="affwp-ajax waiting" src="<?php echo admin_url('images/wpspin_light.gif'); ?>" style="display: none;"/>
 				</span>
 				<div id="affwp_user_search_results"></div>

--- a/includes/integrations/class-rcp.php
+++ b/includes/integrations/class-rcp.php
@@ -161,7 +161,7 @@ class Affiliate_WP_RCP extends Affiliate_WP_Base {
 					<td>
 						<span class="affwp-ajax-search-wrap">
 							<input type="hidden" name="user_id" id="user_id" value="<?php echo esc_attr( $user_id ); ?>" />
-							<input type="text" name="user_name" id="user_name" value="<?php echo esc_attr( $user_name ); ?>" class="affwp-user-search" autocomplete="off" style="width: 300px;" />
+							<input type="text" name="user_name" id="user_name" value="<?php echo esc_attr( $user_name ); ?>" class="affwp-user-search" data-affwp-status="active" autocomplete="off" style="width: 300px;" />
 							<img class="affwp-ajax waiting" src="<?php echo admin_url('images/wpspin_light.gif'); ?>" style="display: none;"/>
 						</span>
 						<div id="affwp_user_search_results"></div>

--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -280,7 +280,7 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 			<span class="affwp-ajax-search-wrap">
 				<span class="affwp-woo-coupon-input-wrap">
 					<input type="hidden" name="user_id" id="user_id" value="<?php echo esc_attr( $user_id ); ?>" />
-					<input type="text" name="user_name" id="user_name" value="<?php echo esc_attr( $user_name ); ?>" class="affwp-user-search" autocomplete="off" />
+					<input type="text" name="user_name" id="user_name" value="<?php echo esc_attr( $user_name ); ?>" class="affwp-user-search" data-affwp-status="active" autocomplete="off" />
 					<img class="affwp-ajax waiting" src="<?php echo admin_url('images/wpspin_light.gif'); ?>" style="display: none;"/>
 				</span>
 				<span id="affwp_user_search_results"></span>


### PR DESCRIPTION
Resolves #665 

This PR refactors the admin user search AJAX to be able to distinguish a specific set of affiliate users that should be included/excluded in query matches using a `data-affwp-status` input attribute.

**Some attribute value examples**

`none` - Only search users that **are not** affiliates (who have no affiliate status).
`any` - Only search users that are affiliates, with any status.
`active` - Only search users that are active affiliates.
`pending` - Only search users that are pending affiliates.

The only reserved values here are `none` and `any`, any custom status added in the future would be automatically supported.

Of course you can just omit this data attribute entirely and **all users** will be searched, affiliates and non-affiliates.

**Performance improvements**

I've also added a simple 500ms delay before AJAX requests are sent, rather than sending them immediately on the `keyup` event. This is a significantly more efficient way of achieving the same result.