### PR TITLE
Issue/745

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -3,8 +3,8 @@ jQuery(document).ready( function($) {
 	$( '#affwp-generate-ref-url' ).submit( function() {
 
 		var url                 = $( this ).find( '#affwp-url' ).val(),
-		    refVar              = $( this ).find( '.affwp-referral-var' ).val(),
-		    affId               = $( this ).find( '.affwp-affiliate-id' ).val(),
+		    refVar              = $( this ).find( 'input[type="hidden"].affwp-referral-var' ).val(),
+		    affId               = $( this ).find( 'input[type="hidden"].affwp-affiliate-id' ).val(),
 		    prettyAffiliateUrls = affwp_vars.pretty_affiliate_urls,
 		    add                 = '';
 

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -2,12 +2,12 @@ jQuery(document).ready( function($) {
 
 	$( '#affwp-generate-ref-url' ).submit( function() {
 
-		var url                 = $( '#affwp-url' ).val(),
-		    refVar              = $( '#affwp-referral-var' ).val(),
-		    affId               = $( '#affwp-affiliate-id' ).val(),
+		var url                 = $( this ).find( '#affwp-url' ).val(),
+		    refVar              = $( this ).find( '.affwp-referral-var' ).val(),
+		    affId               = $( this ).find( '.affwp-affiliate-id' ).val(),
 		    prettyAffiliateUrls = affwp_vars.pretty_affiliate_urls,
-		    add                 = ''
-		
+		    add                 = '';
+
 		if ( prettyAffiliateUrls ) {
 			// pretty affiliate URLs
 
@@ -74,10 +74,10 @@ jQuery(document).ready( function($) {
 		// clean URL to remove any instances of multiple slashes
 		url = url.replace(/([^:])(\/\/+)/g, '$1/');
 
-		$( '.affwp-referral-url-wrap' ).slideDown();
-		$( '#affwp-referral-url' ).val( url ).focus();
+		$( this ).find( '.affwp-referral-url-wrap' ).slideDown();
+		$( this ).find( '#affwp-referral-url' ).val( url ).focus();
 
 		return false;
 	});
-	
+
 });

--- a/templates/dashboard-tab-settings.php
+++ b/templates/dashboard-tab-settings.php
@@ -14,10 +14,10 @@
 		</div>
 
 		<?php do_action( 'affwp_affiliate_dashboard_before_submit', affwp_get_affiliate_id(), affwp_get_affiliate_user_id( affwp_get_affiliate_id() ) ); ?>
-		
+
 		<div class="affwp-save-profile-wrap">
 			<input type="hidden" name="affwp_action" value="update_profile_settings" />
-			<input type="hidden" id="affwp-affiliate-id" name="affiliate_id" value="<?php echo esc_attr( affwp_get_affiliate_id() ); ?>" />
+			<input type="hidden" name="affiliate_id" value="<?php echo esc_attr( affwp_get_affiliate_id() ); ?>" />
 			<input type="submit" class="button" value="<?php esc_attr_e( 'Save Profile Settings', 'affiliate-wp' ); ?>" />
 		</div>
 	</form>

--- a/templates/dashboard-tab-urls.php
+++ b/templates/dashboard-tab-urls.php
@@ -1,7 +1,7 @@
 <div id="affwp-affiliate-dashboard-url-generator" class="affwp-tab-content">
-		
+
 	<h4><?php _e( 'Referral URL Generator', 'affiliate-wp' ); ?></h4>
-	
+
 	<?php if ( 'id' == affwp_get_referral_format() ) : ?>
 		<p><?php printf( __( 'Your affiliate ID is: <strong>%s</strong>', 'affiliate-wp' ), affwp_get_affiliate_id() ); ?></p>
 	<?php elseif ( 'username' == affwp_get_referral_format() ) : ?>
@@ -24,8 +24,8 @@
 		</div>
 
 		<div class="affwp-referral-url-submit-wrap">
-			<input type="hidden" id="affwp-affiliate-id" value="<?php echo esc_attr( affwp_get_referral_format_value() ); ?>" />
-			<input type="hidden" id="affwp-referral-var" value="<?php echo esc_attr( affiliate_wp()->tracking->get_referral_var() ); ?>" />
+			<input type="hidden" class="affwp-affiliate-id" value="<?php echo esc_attr( affwp_get_referral_format_value() ); ?>" />
+			<input type="hidden" class="affwp-referral-var" value="<?php echo esc_attr( affiliate_wp()->tracking->get_referral_var() ); ?>" />
 			<input type="submit" class="button" value="<?php _e( 'Generate URL', 'affiliate-wp' ); ?>" />
 		</div>
 	</form>


### PR DESCRIPTION
Fixes #745

Now using classes for hidden input targeting within the proper scope of their wrapper.

And it turns out that the hidden input for Profile Settings doesn't need an ID at all. Only the `name` attribute is necessary for targeting the form server-side.