### PR TITLE
Issue/508

### DIFF
--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -415,7 +415,7 @@ class Affiliate_WP_Settings {
 						'desc' => __( 'Should affiliates be able to register accounts for themselves?', 'affiliate-wp' ),
 						'type' => 'checkbox'
 					),
-					'enable_recaptcha' => array(
+					'recaptcha_enabled' => array(
 						'name' => __( 'Enable reCAPTCHA', 'affiliate-wp' ),
 						'desc' => __( 'Would you like to prevent bots from registering affiliate accounts using Google reCAPTCHA?', 'affiliate-wp' ),
 						'type' => 'checkbox'

--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -138,7 +138,7 @@ class Affiliate_WP_Settings {
 				}
 			}
 		}
-		
+
 		// Loop through each setting being saved and pass it through a sanitization filter
 		foreach ( $input as $key => $value ) {
 
@@ -249,7 +249,7 @@ class Affiliate_WP_Settings {
 						'name' => __( 'Default Referral Format', 'affiliate-wp' ),
 						'desc' => '<p class="description">' . sprintf( __( 'Show referral URLs to affiliates with either their affiliate ID or Username appended.<br/> For example: <strong>%s or %s</strong>.', 'affiliate-wp' ), esc_url( add_query_arg( affiliate_wp()->tracking->get_referral_var(), '1', home_url( '/' ) ) ), esc_url( add_query_arg( affiliate_wp()->tracking->get_referral_var(), $username, home_url( '/' ) ) ) ) . '</p>',
 						'type' => 'select',
-						'options' => array( 
+						'options' => array(
 							'id'       => __( 'ID', 'affiliate-wp' ),
 							'username' => __( 'Username', 'affiliate-wp' ),
 						),
@@ -415,6 +415,21 @@ class Affiliate_WP_Settings {
 						'desc' => __( 'Should affiliates be able to register accounts for themselves?', 'affiliate-wp' ),
 						'type' => 'checkbox'
 					),
+					'enable_recaptcha' => array(
+						'name' => __( 'Enable reCAPTCHA', 'affiliate-wp' ),
+						'desc' => __( 'Would you like to prevent bots from registering affiliate accounts using Google reCAPTCHA?', 'affiliate-wp' ),
+						'type' => 'checkbox'
+					),
+					'recaptcha_site_key' => array(
+						'name' => __( 'reCAPTCHA Site Key', 'affiliate-wp' ),
+						'desc' => __( 'This is used to identify your site to Google reCAPTCHA.', 'affiliate-wp' ),
+						'type' => 'text'
+					),
+					'recaptcha_secret_key' => array(
+						'name' => __( 'reCAPTCHA Secret Key', 'affiliate-wp' ),
+						'desc' => __( 'This is used for communication between your site and Google reCAPTCHA. Be sure to keep it a secret.', 'affiliate-wp' ),
+						'type' => 'text'
+					),
 					'require_approval' => array(
 						'name' => __( 'Require approval', 'affiliate-wp' ),
 						'desc' => __( 'Require that site admins approve affiliates before they can begin earning referrals?', 'affiliate-wp' ),
@@ -460,7 +475,7 @@ class Affiliate_WP_Settings {
 	 * @return array
 	 */
 	function email_approval_settings( $email_settings ) {
-		
+
 		if ( ! affiliate_wp()->settings->get( 'require_approval' ) ) {
 			return $email_settings;
 		}

--- a/includes/class-register.php
+++ b/includes/class-register.php
@@ -155,8 +155,7 @@ class Affiliate_WP_Register {
 			)
 		);
 
-		$verify = wp_remote_retrieve_body( $verify );
-		$verify = function_exists( 'wp_json_encode' ) ? wp_json_encode( $verify ) : json_encode( $verify );
+		$verify = json_decode( wp_remote_retrieve_body( $verify ) );
 
 		return ( ! empty( $verify->success ) && true === $verify->success );
 	}

--- a/includes/class-register.php
+++ b/includes/class-register.php
@@ -98,11 +98,7 @@ class Affiliate_WP_Register {
 			$this->add_error( 'empty_tos', __( 'Please agree to our terms of use', 'affiliate-wp' ) );
 		}
 
-		if (
-			affwp_is_recaptcha_enabled()
-			&&
-			( empty( $data['g-recaptcha-response'] ) || empty( $data['g-recaptcha-remoteip'] ) || ! $this->recaptcha_response_is_valid( $data['g-recaptcha-response'], $data['g-recaptcha-remoteip'] ) )
-		) {
+		if ( affwp_is_recaptcha_enabled() && ! $this->recaptcha_response_is_valid( $data ) ) {
 			$this->add_error( 'recaptcha_required', __( 'Please verify that you are not a robot', 'affiliate-wp' ) );
 		}
 
@@ -135,12 +131,11 @@ class Affiliate_WP_Register {
 	 *
 	 * @access private
 	 * @since  1.7
-	 * @param  string $response
-	 * @param  string $remote_ip
+	 * @param  array   $data
 	 * @return boolean
 	 */
-	private function recaptcha_response_is_valid( $response, $remote_ip ) {
-		if ( ! affwp_is_recaptcha_enabled() || empty( $response ) || empty( $remote_ip ) ) {
+	private function recaptcha_response_is_valid( $data ) {
+		if ( ! affwp_is_recaptcha_enabled() || empty( $data['g-recaptcha-response'] ) || empty( $data['g-recaptcha-remoteip'] ) ) {
 			return false;
 		}
 
@@ -149,8 +144,8 @@ class Affiliate_WP_Register {
 			array(
 				'body' => array(
 					'secret'   => affiliate_wp()->settings->get( 'recaptcha_secret_key' ),
-					'response' => $response,
-					'remoteip' => $remote_ip
+					'response' => $data['g-recaptcha-response'],
+					'remoteip' => $data['g-recaptcha-remoteip']
 				)
 			)
 		);

--- a/includes/class-register.php
+++ b/includes/class-register.php
@@ -52,14 +52,6 @@ class Affiliate_WP_Register {
 			return;
 		}
 
-		if (
-			affwp_is_recaptcha_enabled()
-			&&
-			( empty( $data['g-recaptcha-response'] ) || empty( $data['g-recaptcha-remoteip'] ) || ! $this->recaptcha_response_is_valid( $data['g-recaptcha-response'], $data['g-recaptcha-remoteip'] ) )
-		) {
-			$this->add_error( 'recaptcha_required', __( 'Please verify that you are not a robot', 'affiliate-wp' ) );
-		}
-
 		do_action( 'affwp_pre_process_register_form' );
 
 		if ( ! is_user_logged_in() ) {
@@ -104,6 +96,14 @@ class Affiliate_WP_Register {
 		$terms_of_use = affiliate_wp()->settings->get( 'terms_of_use' );
 		if ( ! empty( $terms_of_use ) && empty( $_POST['affwp_tos'] ) ) {
 			$this->add_error( 'empty_tos', __( 'Please agree to our terms of use', 'affiliate-wp' ) );
+		}
+
+		if (
+			affwp_is_recaptcha_enabled()
+			&&
+			( empty( $data['g-recaptcha-response'] ) || empty( $data['g-recaptcha-remoteip'] ) || ! $this->recaptcha_response_is_valid( $data['g-recaptcha-response'], $data['g-recaptcha-remoteip'] ) )
+		) {
+			$this->add_error( 'recaptcha_required', __( 'Please verify that you are not a robot', 'affiliate-wp' ) );
 		}
 
 		if ( ! empty( $_POST['affwp_honeypot'] ) ) {

--- a/includes/class-register.php
+++ b/includes/class-register.php
@@ -52,14 +52,14 @@ class Affiliate_WP_Register {
 			return;
 		}
 
-		if ( affwp_is_recaptcha_enabled() && isset( $data['affwp_recaptcha_remoteip'] ) && isset( $data['g-recaptcha-response'] ) ) {
+		if ( affwp_is_recaptcha_enabled() && isset( $data['g-recaptcha-response'] ) && isset( $data['g-recaptcha-remoteip'] ) ) {
 			$response = wp_safe_remote_post(
 				'https://www.google.com/recaptcha/api/siteverify',
 				array(
 					'body' => array(
 						'secret'   => affiliate_wp()->settings->get( 'recaptcha_secret_key' ),
 						'response' => $data['g-recaptcha-response'],
-						'remoteip' => $data['affwp_recaptcha_remoteip']
+						'remoteip' => $data['g-recaptcha-remoteip']
 					)
 				)
 			);

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -126,10 +126,10 @@ function affwp_sanitize_amount( $amount ) {
  * Returns a nicely formatted amount.
  *
  * @since 1.0
- * 
+ *
  * @param string $amount   Price amount to format
  * @param string $decimals Whether or not to use decimals.  Useful when set to false for non-currency numbers.
- * 
+ *
  * @return string $amount Newly formatted amount or Price Not Available
  */
 function affwp_format_amount( $amount, $decimals = true ) {
@@ -153,7 +153,7 @@ function affwp_format_amount( $amount, $decimals = true ) {
 	if ( empty( $amount ) ) {
 		$amount = 0;
 	}
-	
+
 	$decimals  = apply_filters( 'affwp_format_amount_decimals', $decimals ? 2 : 0, $amount );
 	$formatted = number_format( $amount, $decimals, $decimal_sep, $thousands_sep );
 
@@ -198,7 +198,7 @@ function affwp_currency_filter( $amount ) {
 			case "SGD" :
 				$formatted = '&#36;' . $amount;
 				break;
-			case 'RON' : 
+			case 'RON' :
 				$formatted = 'lei' . $amount;
 				break;
 			case "JPY" :
@@ -231,7 +231,7 @@ function affwp_currency_filter( $amount ) {
 			case "SGD" :
 				$formatted = $amount . '&#36;';
 				break;
-			case 'RON' : 
+			case 'RON' :
 				$formatted = $amount . 'lei';
 				break;
 			case "JPY" :
@@ -346,7 +346,7 @@ if ( ! function_exists( 'cal_days_in_month' ) ) {
 
 /**
  * Get the referral format value
- * 
+ *
  * @since 1.6
  * @param string $format referral format passed in via [affiliate_referral_url] shortcode
  * @return string affiliate ID or username
@@ -378,7 +378,7 @@ function affwp_get_referral_format_value( $format = '', $affiliate_id = 0 ) {
 
 /**
  * Gets the referral format from Affiliates -> Settings -> General
- * 
+ *
  * @since  1.6
  * @return string "id" or "username"
  */
@@ -405,5 +405,21 @@ function affwp_is_pretty_referral_urls() {
 	}
 
 	return (bool) false;
+
+}
+
+/**
+ * Checks whether reCAPTCHA is enabled since it requires three options
+ *
+ * @since  1.7
+ * @return boolean
+ */
+function affwp_is_recaptcha_enabled() {
+
+	$enabled     = affiliate_wp()->settings->get( 'enable_recaptcha', 0 );
+	$site_key    = affiliate_wp()->settings->get( 'recaptcha_site_key', '' );
+	$secret_key  = affiliate_wp()->settings->get( 'recaptcha_secret_key', '' );
+
+	return ( ! empty( $enabled ) && ! empty( $site_key ) && ! empty( $secret_key ) );
 
 }

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -416,10 +416,11 @@ function affwp_is_pretty_referral_urls() {
  */
 function affwp_is_recaptcha_enabled() {
 
-	$enabled     = affiliate_wp()->settings->get( 'enable_recaptcha', 0 );
-	$site_key    = affiliate_wp()->settings->get( 'recaptcha_site_key', '' );
-	$secret_key  = affiliate_wp()->settings->get( 'recaptcha_secret_key', '' );
+	$checkbox   = affiliate_wp()->settings->get( 'recaptcha_enabled', 0 );
+	$site_key   = affiliate_wp()->settings->get( 'recaptcha_site_key', '' );
+	$secret_key = affiliate_wp()->settings->get( 'recaptcha_secret_key', '' );
+	$enabled    = ( ! empty( $checkbox ) && ! empty( $site_key ) && ! empty( $secret_key ) );
 
-	return ( ! empty( $enabled ) && ! empty( $site_key ) && ! empty( $secret_key ) );
+	return (bool) apply_filters( 'affwp_recaptcha_enabled', $enabled );
 
 }

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -2,10 +2,10 @@
 
 /**
  *  Determines whether the current admin page is an AffiliateWP admin page.
- *  
- *  Only works after the `wp_loaded` hook, & most effective 
+ *
+ *  Only works after the `wp_loaded` hook, & most effective
  *  starting on `admin_menu` hook.
- *  
+ *
  *  @since 1.0
  *  @return bool True if AffiliateWP admin page.
  */
@@ -14,7 +14,7 @@ function affwp_is_admin_page() {
 	if ( ! is_admin() || ! did_action( 'wp_loaded' ) ) {
 		$ret = false;
 	}
-	
+
 	if( ! isset( $_GET['page'] ) ) {
 		$ret = false;
 	}
@@ -33,15 +33,15 @@ function affwp_is_admin_page() {
 		'affwp-what-is-new',
 		'affwp-credits'
 	);
-		
+
 	$ret = in_array( $page, $pages );
-	
+
 	return apply_filters( 'affwp_is_admin_page', $ret );
 }
 
 /**
  *  Load the admin scripts
- *  
+ *
  *  @since 1.0
  *  @return void
  */
@@ -74,7 +74,7 @@ add_action( 'admin_enqueue_scripts', 'affwp_admin_scripts' );
 
 /**
  *  Load the admin styles
- *  
+ *
  *  @since 1.0
  *  @return void
  */
@@ -82,15 +82,15 @@ function affwp_admin_styles() {
 
 	$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
-	// Dashicons and our main admin CSS need to be on all pages for the menu icon	
+	// Dashicons and our main admin CSS need to be on all pages for the menu icon
 	wp_enqueue_style( 'dashicons' );
 	wp_enqueue_style( 'affwp-admin', AFFILIATEWP_PLUGIN_URL . 'assets/css/admin' . $suffix . '.css', AFFILIATEWP_VERSION );
-	
+
 	if( ! affwp_is_admin_page() ) {
 		return;
 	}
 
-	// jQuery UI styles are loaded on our admin pages only 
+	// jQuery UI styles are loaded on our admin pages only
 	$ui_style = ( 'classic' == get_user_option( 'admin_color' ) ) ? 'classic' : 'fresh';
 	wp_enqueue_style( 'jquery-ui-css', AFFILIATEWP_PLUGIN_URL . 'assets/css/jquery-ui-' . $ui_style . '.min.css' );
 }
@@ -98,7 +98,7 @@ add_action( 'admin_enqueue_scripts', 'affwp_admin_styles' );
 
 /**
  *  Load the frontend scripts and styles
- *  
+ *
  *  @since 1.0
  *  @return void
  */
@@ -111,7 +111,7 @@ function affwp_frontend_scripts_and_styles() {
 	}
 
 	if ( has_shortcode( $post->post_content, 'affiliate_area' ) || apply_filters( 'affwp_force_frontend_scripts', false ) ) {
-		
+
 		$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 		wp_enqueue_script( 'affwp-frontend', AFFILIATEWP_PLUGIN_URL . 'assets/js/frontend' . $suffix . '.js', array( 'jquery' ), AFFILIATEWP_VERSION );
@@ -124,6 +124,10 @@ function affwp_frontend_scripts_and_styles() {
 		));
 		wp_enqueue_style( 'affwp-forms', AFFILIATEWP_PLUGIN_URL . 'assets/css/forms' . $suffix . '.css', AFFILIATEWP_VERSION );
 		wp_enqueue_style( 'dashicons' );
+
+		if ( affwp_is_recaptcha_enabled() ) {
+			wp_enqueue_script( 'affwp-recaptcha', 'https://www.google.com/recaptcha/api.js', array(), AFFILIATEWP_VERSION );
+		}
 	}
 
 }
@@ -131,7 +135,7 @@ add_action( 'wp_enqueue_scripts', 'affwp_frontend_scripts_and_styles' );
 
 /**
  *  Load the frontend creative styles for the [affiliate_creative] and [affiliate_creatives] shortcodes
- *  
+ *
  *  @since 1.1.4
  *  @return void
  */

--- a/templates/register.php
+++ b/templates/register.php
@@ -98,6 +98,14 @@ if( ! is_user_logged_in() && ! empty( $errors ) ) {
 			</p>
 		<?php endif; ?>
 
+		<?php if ( affwp_is_recaptcha_enabled() ) : ?>
+			<div class="g-recaptcha" data-sitekey="<?php echo esc_attr( affiliate_wp()->settings->get( 'recaptcha_site_key' ) ); ?>"></div>
+
+			<p>
+				<input type="hidden" name="affwp_recaptcha_remoteip" value=<?php echo esc_attr( $_SERVER['REMOTE_ADDR'] ); ?> />
+			</p>
+		<?php endif; ?>
+
 		<?php do_action( 'affwp_register_fields_before_submit' ); ?>
 
 		<p>

--- a/templates/register.php
+++ b/templates/register.php
@@ -102,7 +102,7 @@ if( ! is_user_logged_in() && ! empty( $errors ) ) {
 			<div class="g-recaptcha" data-sitekey="<?php echo esc_attr( affiliate_wp()->settings->get( 'recaptcha_site_key' ) ); ?>"></div>
 
 			<p>
-				<input type="hidden" name="g-recaptcha-remoteip" value=<?php echo esc_attr( $_SERVER['REMOTE_ADDR'] ); ?> />
+				<input type="hidden" name="g-recaptcha-remoteip" value=<?php echo esc_attr( affiliate_wp()->tracking->get_ip() ); ?> />
 			</p>
 		<?php endif; ?>
 

--- a/templates/register.php
+++ b/templates/register.php
@@ -102,7 +102,7 @@ if( ! is_user_logged_in() && ! empty( $errors ) ) {
 			<div class="g-recaptcha" data-sitekey="<?php echo esc_attr( affiliate_wp()->settings->get( 'recaptcha_site_key' ) ); ?>"></div>
 
 			<p>
-				<input type="hidden" name="affwp_recaptcha_remoteip" value=<?php echo esc_attr( $_SERVER['REMOTE_ADDR'] ); ?> />
+				<input type="hidden" name="g-recaptcha-remoteip" value=<?php echo esc_attr( $_SERVER['REMOTE_ADDR'] ); ?> />
 			</p>
 		<?php endif; ?>
 


### PR DESCRIPTION
Implements #508 

Adds reCAPTCHA settings to the Misc settings tab:

![screen_shot_2015-07-13_at_2_46_59_pm](https://cloud.githubusercontent.com/assets/522158/8659160/72f5ae60-296e-11e5-9123-b5915c3ad77b.png)

When all three options are satisfied, Google reCAPTCHA will be shown during registration:

![screen shot 2015-07-13 at 2 46 43 pm](https://cloud.githubusercontent.com/assets/522158/8659209/b4e73758-296e-11e5-953a-b003687c6783.png)

If the reCAPTCHA is not verified, the user will receive an error:

![screen shot 2015-07-13 at 2 51 35 pm](https://cloud.githubusercontent.com/assets/522158/8659221/cb80605c-296e-11e5-88b8-ee54342a3d8c.png)
