### PR TITLE
Issue/659

### DIFF
--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -138,7 +138,7 @@ class Affiliate_WP_Settings {
 				}
 			}
 		}
-		
+
 		// Loop through each setting being saved and pass it through a sanitization filter
 		foreach ( $input as $key => $value ) {
 
@@ -249,7 +249,7 @@ class Affiliate_WP_Settings {
 						'name' => __( 'Default Referral Format', 'affiliate-wp' ),
 						'desc' => '<p class="description">' . sprintf( __( 'Show referral URLs to affiliates with either their affiliate ID or Username appended.<br/> For example: <strong>%s or %s</strong>.', 'affiliate-wp' ), esc_url( add_query_arg( affiliate_wp()->tracking->get_referral_var(), '1', home_url( '/' ) ) ), esc_url( add_query_arg( affiliate_wp()->tracking->get_referral_var(), $username, home_url( '/' ) ) ) ) . '</p>',
 						'type' => 'select',
-						'options' => array( 
+						'options' => array(
 							'id'       => __( 'ID', 'affiliate-wp' ),
 							'username' => __( 'Username', 'affiliate-wp' ),
 						),
@@ -341,6 +341,11 @@ class Affiliate_WP_Settings {
 			/** Email Settings */
 			'emails' => apply_filters( 'affwp_settings_emails',
 				array(
+					'disable_all_emails' => array(
+						'name' => __( 'Disable All Emails', 'affiliate-wp' ),
+						'desc' => __( 'Should all email notifications be disabled?', 'affiliate-wp' ),
+						'type' => 'checkbox'
+					),
 					'email_logo' => array(
 						'name' => __( 'Logo', 'affiliate-wp' ),
 						'desc' => __( 'Upload or choose a logo to be displayed at the top of emails.', 'affiliate-wp' ),
@@ -460,7 +465,7 @@ class Affiliate_WP_Settings {
 	 * @return array
 	 */
 	function email_approval_settings( $email_settings ) {
-		
+
 		if ( ! affiliate_wp()->settings->get( 'require_approval' ) ) {
 			return $email_settings;
 		}

--- a/includes/emails/class-affwp-emails.php
+++ b/includes/emails/class-affwp-emails.php
@@ -506,6 +506,7 @@ class Affiliate_WP_Emails {
 	/**
 	 * Check if all emails should be disabled
 	 *
+	 * @since  1.7
 	 * @return bool
 	 */
 	public function is_email_disabled() {

--- a/includes/emails/class-affwp-emails.php
+++ b/includes/emails/class-affwp-emails.php
@@ -13,7 +13,7 @@
 
 
 // Exit if accessed directly
-if( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) exit;
 
 
 /**
@@ -101,7 +101,7 @@ class Affiliate_WP_Emails {
 	 */
 	public function __construct() {
 
-		if( 'none' === $this->get_template() ) {
+		if ( 'none' === $this->get_template() ) {
 			$this->html = false;
 		}
 
@@ -130,7 +130,7 @@ class Affiliate_WP_Emails {
 	public function get_from_name() {
 		global $affwp_options;
 
-		if( ! $this->from_name ) {
+		if ( ! $this->from_name ) {
 			$this->from_name = affiliate_wp()->settings->get( 'from_name', get_bloginfo( 'name' ) );
 		}
 
@@ -145,7 +145,7 @@ class Affiliate_WP_Emails {
 	 * @return string The email from address
 	 */
 	public function get_from_address() {
-		if( ! $this->from_address ) {
+		if ( ! $this->from_address ) {
 			$this->from_address = affiliate_wp()->settings->get( 'from_email', get_option( 'admin_email' ) );
 		}
 
@@ -160,9 +160,9 @@ class Affiliate_WP_Emails {
 	 * @return string The email content type
 	 */
 	public function get_content_type() {
-		if( ! $this->content_type && $this->html ) {
+		if ( ! $this->content_type && $this->html ) {
 			$this->content_type = apply_filters( 'affwp_email_default_content_type', 'text/html', $this );
-		} elseif( ! $this->html ) {
+		} elseif ( ! $this->html ) {
 			$this->content_type = 'text/plain';
 		}
 
@@ -177,7 +177,7 @@ class Affiliate_WP_Emails {
 	 * @return string The email headers
 	 */
 	public function get_headers() {
-		if( ! $this->headers ) {
+		if ( ! $this->headers ) {
 			$this->headers  = "From: {$this->get_from_name()} <{$this->get_from_address()}>\r\n";
 			$this->headers .= "Reply-To: {$this->get_from_address()}\r\n";
 			$this->headers .= "Content-Type: {$this->get_content_type()}; charset=utf-8\r\n";
@@ -210,7 +210,7 @@ class Affiliate_WP_Emails {
 	 * @return string|null
 	 */
 	public function get_template() {
-		if( ! $this->template ) {
+		if ( ! $this->template ) {
 			$this->template = affiliate_wp()->settings->get( 'email_template', 'default' );
 		}
 
@@ -238,7 +238,7 @@ class Affiliate_WP_Emails {
 	 */
 	public function build_email( $message ) {
 
-		if( false === $this->html ) {
+		if ( false === $this->html ) {
 			return apply_filters( 'affwp_email_message', wp_strip_all_tags( $message ), $this );
 		}
 
@@ -291,7 +291,7 @@ class Affiliate_WP_Emails {
 	 */
 	public function send( $to, $subject, $message, $attachments = '' ) {
 
-		if( ! did_action( 'init' ) && ! did_action( 'admin_init' ) ) {
+		if ( ! did_action( 'init' ) && ! did_action( 'admin_init' ) ) {
 			_doing_it_wrong( __FUNCTION__, __( 'You cannot send emails with AffWP_Emails until init/admin_init has been reached', 'affiliate-wp' ), null );
 			return false;
 		}
@@ -362,7 +362,7 @@ class Affiliate_WP_Emails {
 	 * @since 1.6
 	 */
 	public function text_to_html( $message ) {
-		if( 'text/html' === $this->content_type || true === $this->html ) {
+		if ( 'text/html' === $this->content_type || true === $this->html ) {
 			$message = wpautop( $message );
 		}
 
@@ -380,7 +380,7 @@ class Affiliate_WP_Emails {
 	private function parse_tags( $content ) {
 
 		// Make sure there's at least one tag
-		if( empty( $this->tags ) || ! is_array( $this->tags ) ) {
+		if ( empty( $this->tags ) || ! is_array( $this->tags ) ) {
 			return $content;
 		}
 
@@ -485,7 +485,7 @@ class Affiliate_WP_Emails {
 		$tag = $m[1];
 
 		// Return tag if not set
-		if( ! $this->email_tag_exists( $tag ) ) {
+		if ( ! $this->email_tag_exists( $tag ) ) {
 			return $m[0];
 		}
 

--- a/includes/emails/class-affwp-emails.php
+++ b/includes/emails/class-affwp-emails.php
@@ -243,7 +243,7 @@ class Affiliate_WP_Emails {
 		}
 
 		$message = $this->text_to_html( $message );
-		
+
 		ob_start();
 
 		affiliate_wp()->templates->get_template_part( 'emails/header', $this->get_template(), true );
@@ -293,6 +293,11 @@ class Affiliate_WP_Emails {
 
 		if( ! did_action( 'init' ) && ! did_action( 'admin_init' ) ) {
 			_doing_it_wrong( __FUNCTION__, __( 'You cannot send emails with AffWP_Emails until init/admin_init has been reached', 'affiliate-wp' ), null );
+			return false;
+		}
+
+		// Don't send anything if emails have been disabled
+		if ( $this->is_email_disabled() ) {
 			return false;
 		}
 
@@ -496,6 +501,18 @@ class Affiliate_WP_Emails {
 	 */
 	public function email_tag_exists( $tag ) {
 		return array_key_exists( $tag, $this->tags );
+	}
+
+	/**
+	 * Check if all emails should be disabled
+	 *
+	 * @return bool
+	 */
+	public function is_email_disabled() {
+		$disabled = affiliate_wp()->settings->get( 'disable_all_emails', false );
+		$disabled = (bool) apply_filters( 'affwp_disable_all_emails', $disabled );
+
+		return $disabled;
 	}
 
 }


### PR DESCRIPTION
Resolves #659 

Allows users to disable all email notifications with a simple checkbox in the **Settings > Emails** tab.

![screen shot 2015-07-14 at 11 04 29 am](https://cloud.githubusercontent.com/assets/522158/8678076/2276e8e6-2a18-11e5-819d-7bc9ff9acbb6.png)

The `affwp_disable_all_emails` filter can be used to control this behavior programmatically.