### PR TITLE
Issue/767

### DIFF
--- a/includes/integrations/class-edd.php
+++ b/includes/integrations/class-edd.php
@@ -363,7 +363,7 @@ class Affiliate_WP_EDD extends Affiliate_WP_Base {
 
 		foreach ( $downloads as $key => $item ) {
 
-			if ( get_post_meta( $item['id'], "_affwp_{$this->context}_referrals_disabled", true ) ) {
+			if ( get_post_meta( $item['id'], '_affwp_' . $this->context . '_referrals_disabled', true ) ) {
 				continue; // Referrals are disabled on this product
 			}
 

--- a/includes/integrations/class-edd.php
+++ b/includes/integrations/class-edd.php
@@ -339,7 +339,7 @@ class Affiliate_WP_EDD extends Affiliate_WP_Base {
 	*/
 	public function reference_link( $reference = 0, $referral ) {
 
-		if( empty( $referral->context ) || 'edd' != $referral->context ) {
+		if ( empty( $referral->context ) || 'edd' != $referral->context ) {
 
 			return $reference;
 

--- a/includes/integrations/class-edd.php
+++ b/includes/integrations/class-edd.php
@@ -133,12 +133,12 @@ class Affiliate_WP_EDD extends Affiliate_WP_Base {
 
 				} else {
 					// new referral
-					
+
 					if ( 0 == $referral_total && affiliate_wp()->settings->get( 'ignore_zero_referrals' ) ) {
 						return false; // Ignore a zero amount referral
 					}
 
-					$referral_id = affiliate_wp()->referrals->add( 
+					$referral_id = affiliate_wp()->referrals->add(
 						array(
 							'amount'       => $referral_total,
 							'reference'    => $payment_id,
@@ -165,7 +165,7 @@ class Affiliate_WP_EDD extends Affiliate_WP_Base {
 		$downloads = apply_filters( 'affwp_get_edd_cart_details', edd_get_payment_meta_cart_details( $payment_id ) );
 
 		if ( is_array( $downloads ) ) {
-			
+
 			// Calculate the referral amount based on product prices
 			$referral_total = 0.00;
 
@@ -182,7 +182,7 @@ class Affiliate_WP_EDD extends Affiliate_WP_Base {
 				}
 
 				if( class_exists( 'EDD_Simple_Shipping' ) ) {
-					
+
 					if( isset( $download['fees'] ) ) {
 
 						foreach( $download['fees'] as $fee_id => $fee ) {
@@ -192,7 +192,7 @@ class Affiliate_WP_EDD extends Affiliate_WP_Base {
 								if( ! affiliate_wp()->settings->get( 'exclude_shipping' ) ) {
 
 									$amount += $fee['amount'];
-									
+
 								}
 
 							}
@@ -200,7 +200,7 @@ class Affiliate_WP_EDD extends Affiliate_WP_Base {
 						}
 
 					}
-					
+
 				}
 
 				$referral_total += $this->calculate_referral_amount( $amount, $payment_id, $download['id'] );
@@ -277,7 +277,7 @@ class Affiliate_WP_EDD extends Affiliate_WP_Base {
 		$name         = affiliate_wp()->affiliates->get_affiliate_name( $affiliate_id );
 
 		edd_insert_payment_note( $payment_id, sprintf( __( 'Referral #%d for %s recorded for %s', 'affiliate-wp' ), $referral->referral_id, $amount, $name ) );
-		
+
 	}
 
 	/**
@@ -358,24 +358,19 @@ class Affiliate_WP_EDD extends Affiliate_WP_Base {
 	*/
 	public function get_referral_description( $payment_id = 0 ) {
 
-		$description = '';
+		$description = array();
 		$downloads   = edd_get_payment_meta_downloads( $payment_id );
-		foreach( $downloads as $key => $item ) {
 
-			if( get_post_meta( $item['id'], '_affwp_' . $this->context . '_referrals_disabled', true ) ) {
+		foreach ( $downloads as $key => $item ) {
+
+			if ( get_post_meta( $item['id'], "_affwp_{$this->context}_referrals_disabled", true ) ) {
 				continue; // Referrals are disabled on this product
 			}
 
-			$description .= get_the_title( $item['id'] );
-
-			if( $key + 1 < count( $downloads ) ) {
-				$description .= ', ';
-			}
-
+			$description[] = get_the_title( $item['id'] );
 		}
 
-		return $description;
-
+		return implode( ', ', $description );
 	}
 
 	/**
@@ -422,12 +417,12 @@ class Affiliate_WP_EDD extends Affiliate_WP_Base {
 	 * @since   1.1
 	*/
 	public function store_discount_affiliate( $details, $discount_id = 0 ) {
-		
-		if ( empty( $_POST['user_name'] ) ) {		
+
+		if ( empty( $_POST['user_name'] ) ) {
 			delete_post_meta( $discount_id, 'affwp_discount_affiliate' );
 			return;
 		}
-		
+
 		if( empty( $_POST['user_id'] ) && empty( $_POST['user_name'] ) ) {
 			return;
 		}
@@ -504,7 +499,7 @@ class Affiliate_WP_EDD extends Affiliate_WP_Base {
 			);
 
 		}
-		
+
 		return $settings;
 	}
 
@@ -525,7 +520,7 @@ class Affiliate_WP_EDD extends Affiliate_WP_Base {
 			);
 
 		}
-		
+
 		return $settings;
 	}
 


### PR DESCRIPTION
Fixes #767 

This PR fixes the trailing comma when one download item in checkout has referrals disabled.

I didn't realize until after I already did this issue that there was not a milestone assigned yet. Sorry about that.