### PR TITLE
Issue/677

### DIFF
--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -69,10 +69,12 @@ class Affiliate_WP_Settings {
 
 				$name = isset( $option['name'] ) ? $option['name'] : '';
 
+				$callback = ! empty( $option['callback'] ) ? $option['callback'] : array( $this, $option['type'] . '_callback' );
+
 				add_settings_field(
 					'affwp_settings[' . $key . ']',
 					$name,
-					is_callable( array( $this, $option[ 'type' ] . '_callback' ) ) ? array( $this, $option[ 'type' ] . '_callback' ) : array( $this, 'missing_callback' ),
+					is_callable( $callback ) ? $callback : array( $this, 'missing_callback' ),
 					'affwp_settings_' . $tab,
 					'affwp_settings_' . $tab,
 					array(


### PR DESCRIPTION
Resolves #677

Simple change that allows custom settings callbacks to be defined per option, and take priority over baked-in callback methods so they can be overridden when necessary.

So you can do this:

```php
function my_custom_settings( $settings ) {
	$settings['general']['custom'] = array(
		'name'     => 'Custom',
		'type'     => 'something',
		'callback' => 'my_something_callback'
	);

	return $settings;
}
add_filter( 'affwp_settings', 'my_custom_settings' );

function my_something_callback( $args ) {
	echo 'Do things';
}
```