### PR TITLE
Issue/531

### DIFF
--- a/includes/admin/referrals/edit.php
+++ b/includes/admin/referrals/edit.php
@@ -45,7 +45,7 @@ $referral = affwp_get_referral( absint( $_GET['referral_id'] ) );
 				</th>
 
 				<td>
-					<input type="text" name="description" id="description" value="<?php echo esc_attr( $referral->description ); ?>" />
+					<textarea name="description" id="description" rows="5" cols="60"><?php echo esc_html( $referral->description ); ?></textarea>
 					<p class="description"><?php _e( 'Enter a description for this referral.', 'affiliate-wp' ); ?></p>
 				</td>
 

--- a/includes/admin/referrals/referrals.php
+++ b/includes/admin/referrals/referrals.php
@@ -34,12 +34,12 @@ function affwp_referrals_admin() {
 			<h2><?php _e( 'Referrals', 'affiliate-wp' ); ?></h2>
 
 			<?php do_action( 'affwp_referrals_page_top' ); ?>
-			
+
 			<div id="affwp-referrals-export-wrap">
 				<a href="<?php echo esc_url( add_query_arg( 'action', 'add_referral' ) ); ?>" class="button-secondary"><?php _e( 'Add New Referral', 'affiliate-wp' ); ?></a>
 				<button class="button-primary affwp-referrals-export-toggle"><?php _e( 'Generate Payout File', 'affiliate-wp' ); ?></button>
 				<button class="button-primary affwp-referrals-export-toggle" style="display:none"><?php _e( 'Close', 'affiliate-wp' ); ?></button>
-				
+
 				<?php do_action( 'affwp_referrals_page_buttons' ); ?>
 
 				<form id="affwp-referrals-export-form" style="display:none;" action="<?php echo admin_url( 'admin.php?page=affiliate-wp-referrals' ); ?>" method="post">
@@ -56,7 +56,7 @@ function affwp_referrals_admin() {
 
 			</div>
 			<form id="affwp-referrals-filter-form" method="get" action="<?php echo admin_url( 'admin.php?page=affiliate-wp-referrals' ); ?>">
-			
+
 				<?php $referrals_table->search_box( __( 'Search', 'affiliate-wp' ), 'affwp-referrals' ); ?>
 
 				<input type="hidden" name="page" value="affiliate-wp-referrals" />
@@ -261,9 +261,13 @@ class AffWP_Referrals_Table extends WP_List_Table {
 	 */
 	public function column_default( $referral, $column_name ) {
 		switch( $column_name ){
-			
+
 			case 'date' :
 				$value = date_i18n( get_option( 'date_format' ), strtotime( $referral->date ) );
+				break;
+
+			case 'description' :
+				$value = wp_trim_words( $referral->description, 10 );
 				break;
 
 			default:
@@ -321,7 +325,7 @@ class AffWP_Referrals_Table extends WP_List_Table {
 	public function column_affiliate( $referral ) {
 		return '<a href="' . admin_url( 'admin.php?page=affiliate-wp-referrals&affiliate_id=' . $referral->affiliate_id ) . '">' . affiliate_wp()->affiliates->get_affiliate_name( $referral->affiliate_id ) . '</a>';
 	}
-	
+
 	/**
 	 * Render the reference column
 	 *
@@ -345,38 +349,38 @@ class AffWP_Referrals_Table extends WP_List_Table {
 	 * @return string The actions HTML
 	 */
 	public function column_actions( $referral ) {
-		
+
 		$action_links   = array();
 
 		if( 'paid' == $referral->status ) {
-			
+
 			$action_links[] = '<a href="' . esc_url( add_query_arg( array( 'action' => 'mark_as_unpaid', 'referral_id' => $referral->referral_id ) ) ) . '" class="mark-as-paid">' . __( 'Mark as Unpaid', 'affiliate-wp' ) . '</a>';
-	
+
 		} else {
 
-			if( 'unpaid' == $referral->status ) {	
+			if( 'unpaid' == $referral->status ) {
 
 				$action_links[] = '<a href="' . esc_url( add_query_arg( array( 'action' => 'mark_as_paid', 'referral_id' => $referral->referral_id ) ) ) . '" class="mark-as-paid">' . __( 'Mark as Paid', 'affiliate-wp' ) . '</a>';
 
 			}
 
 			if( 'rejected' == $referral->status || 'pending' == $referral->status ) {
-			
+
 				$action_links[] = '<a href="' . esc_url( add_query_arg( array( 'action' => 'accept', 'referral_id' => $referral->referral_id ) ) ) . '" class="reject">' . __( 'Accept', 'affiliate-wp' ) . '</a>';
-			
+
 			}
 
 			if( 'rejected' != $referral->status ) {
-			
+
 				$action_links[] = '<a href="' . esc_url( add_query_arg( array( 'action' => 'reject', 'referral_id' => $referral->referral_id ) ) ) . '" class="reject">' . __( 'Reject', 'affiliate-wp' ) . '</a>';
-			
+
 			}
 
 		}
-		
+
 		$action_links[] = '<span class="trash"><a href="' . esc_url( add_query_arg( array( 'action' => 'edit_referral', 'referral_id' => $referral->referral_id ) ) ) . '" class="edit">' . __( 'Edit', 'affiliate-wp' ) . '</a></span>';
 		$action_links[] = '<span class="trash"><a href="' . wp_nonce_url( add_query_arg( array( 'affwp_action' => 'process_delete_referral', 'referral_id' => $referral->referral_id ) ), 'affwp_delete_referral_nonce' ) . '" class="delete">' . __( 'Delete', 'affiliate-wp' ) . '</a></span>';
-		
+
 		$action_links   = array_unique( apply_filters( 'affwp_referral_action_links', $action_links, $referral ) );
 
 		return '<div class="action-links">' . implode( ' | ', $action_links ) . '</div>';
@@ -400,7 +404,7 @@ class AffWP_Referrals_Table extends WP_List_Table {
 	 * @return void
 	 */
 	public function bulk_actions( $which = '' ) {
-		
+
 		if ( is_null( $this->_actions ) ) {
 			$no_new_actions = $this->_actions = $this->get_bulk_actions();
 			$this->_actions = array_intersect_assoc( $this->_actions, $no_new_actions );
@@ -486,11 +490,11 @@ class AffWP_Referrals_Table extends WP_List_Table {
 		}
 
 		foreach ( $ids as $id ) {
-			
+
 			if ( 'delete' === $this->current_action() ) {
 				affwp_delete_referral( $id );
 			}
-			
+
 			if ( 'reject' === $this->current_action() ) {
 				affwp_set_referral_status( $id, 'rejected' );
 			}
@@ -522,7 +526,7 @@ class AffWP_Referrals_Table extends WP_List_Table {
 	 */
 	public function get_referral_counts() {
 
-		$affiliate_id = isset( $_GET['affiliate_id'] ) ? $_GET['affiliate_id'] : ''; 
+		$affiliate_id = isset( $_GET['affiliate_id'] ) ? $_GET['affiliate_id'] : '';
 
 		if( is_array( $affiliate_id ) ) {
 			$affiliate_id = array_map( 'absint', $affiliate_id );
@@ -545,17 +549,17 @@ class AffWP_Referrals_Table extends WP_List_Table {
 	 * @return array $referrals_data Array of all the data for the Affiliates
 	 */
 	public function referrals_data() {
-		
+
 		$page      = isset( $_GET['paged'] )        ? absint( $_GET['paged'] ) : 1;
-		$status    = isset( $_GET['status'] )       ? $_GET['status']          : ''; 
-		$affiliate = isset( $_GET['affiliate_id'] ) ? $_GET['affiliate_id']    : ''; 
-		$reference = isset( $_GET['reference'] )    ? $_GET['reference']       : ''; 
-		$context   = isset( $_GET['context'] )      ? $_GET['context']         : ''; 
-		$from      = isset( $_GET['filter_from'] )  ? $_GET['filter_from']     : ''; 
-		$to        = isset( $_GET['filter_to'] )    ? $_GET['filter_to']       : ''; 
+		$status    = isset( $_GET['status'] )       ? $_GET['status']          : '';
+		$affiliate = isset( $_GET['affiliate_id'] ) ? $_GET['affiliate_id']    : '';
+		$reference = isset( $_GET['reference'] )    ? $_GET['reference']       : '';
+		$context   = isset( $_GET['context'] )      ? $_GET['context']         : '';
+		$from      = isset( $_GET['filter_from'] )  ? $_GET['filter_from']     : '';
+		$to        = isset( $_GET['filter_to'] )    ? $_GET['filter_to']       : '';
 		$order     = isset( $_GET['order'] )        ? $_GET['order']           : 'DESC';
 		$orderby   = isset( $_GET['orderby'] )      ? $_GET['orderby']         : 'referral_id';
-		$referral  = ''; 
+		$referral  = '';
 		$is_search = false;
 
 		$date = array();

--- a/includes/admin/referrals/referrals.php
+++ b/includes/admin/referrals/referrals.php
@@ -268,6 +268,7 @@ class AffWP_Referrals_Table extends WP_List_Table {
 
 			case 'description' :
 				$value = wp_trim_words( $referral->description, 10 );
+				$value = (string) apply_filters( 'affwp_referral_description_column', $value, $referral->description );
 				break;
 
 			default:

--- a/templates/dashboard-tab-referrals.php
+++ b/templates/dashboard-tab-referrals.php
@@ -35,7 +35,7 @@
 				<?php foreach ( $referrals as $referral ) : ?>
 					<tr>
 						<td class="referral-amount"><?php echo affwp_currency_filter( affwp_format_amount( $referral->amount ) ); ?></td>
-						<td class="referral-description"><?php echo nl2br( $referral->description ); ?></td>
+						<td class="referral-description"><?php echo wp_kses_post( nl2br( $referral->description ) ); ?></td>
 						<td class="referral-status <?php echo $referral->status; ?>"><?php echo affwp_get_referral_status_label( $referral ); ?></td>
 						<td class="referral-date"><?php echo date_i18n( get_option( 'date_format' ), strtotime( $referral->date ) ); ?></td>
 						<?php do_action( 'affwp_referrals_dashboard_td', $referral ); ?>

--- a/templates/dashboard-tab-referrals.php
+++ b/templates/dashboard-tab-referrals.php
@@ -35,7 +35,7 @@
 				<?php foreach ( $referrals as $referral ) : ?>
 					<tr>
 						<td class="referral-amount"><?php echo affwp_currency_filter( affwp_format_amount( $referral->amount ) ); ?></td>
-						<td class="referral-description"><?php echo $referral->description; ?></td>
+						<td class="referral-description"><?php echo nl2br( $referral->description ); ?></td>
 						<td class="referral-status <?php echo $referral->status; ?>"><?php echo affwp_get_referral_status_label( $referral ); ?></td>
 						<td class="referral-date"><?php echo date_i18n( get_option( 'date_format' ), strtotime( $referral->date ) ); ?></td>
 						<?php do_action( 'affwp_referrals_dashboard_td', $referral ); ?>


### PR DESCRIPTION
Resolves #531 

Allows multiple lines in referral descriptions.

#### Edit Referral Screen

![screen shot 2015-07-15 at 2 16 38 pm](https://cloud.githubusercontent.com/assets/522158/8707616/6a534f6c-2afc-11e5-9952-0ccefb555e83.png)

#### List Table Screen

Truncates descriptions to 10 words using `wp_trim_words()`.

The output here can be changed using the `affwp_referral_reference_column` filter.

![screen shot 2015-07-15 at 2 16 50 pm](https://cloud.githubusercontent.com/assets/522158/8707624/7920d140-2afc-11e5-859f-57d7969dd4b0.png)

#### Front-end Template

I opted to use `nl2br()` rather than `wpautop()` in order to preserve the markup people may be expecting and not introduce another element into the table. Table cells currently don't have any `<p>` tags.

![screen shot 2015-07-15 at 2 17 02 pm](https://cloud.githubusercontent.com/assets/522158/8707633/8ea0dc4a-2afc-11e5-91f5-f2583685741e.png)
