### PR TITLE
Issue/520

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -66,6 +66,9 @@ table.affwp_table td a {
 #affwp-dashboard-widgets-wrap .postbox h3 {
 	cursor: default;
 }
+#affwp-dashboard-widgets-wrap .muted {
+	color: #999;
+}
 
 /* Affiliate Overview */
 #affwp-dashboard-widgets-wrap .postbox {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -159,7 +159,7 @@ jQuery(document).ready(function($) {
 		file_frame.on( 'select', function() {
 			var attachment = file_frame.state().get('selection').first().toJSON();
 			formfield.val(attachment.url);
-		
+
 			var img = $('<img />');
 			img.attr('src', attachment.url);
 			// replace previous image with new one if selected
@@ -167,7 +167,7 @@ jQuery(document).ready(function($) {
 
 			// show preview div when image exists
 			if ( $('#preview_image img') ) {
-				$('#preview_image').show();	
+				$('#preview_image').show();
 			}
 		});
 
@@ -185,4 +185,26 @@ jQuery(document).ready(function($) {
 		return false;
 
 	});
+
+	$('body').on('submit', '#affiliate-wp-migrate-user-accounts input:checkbox', function(e) {
+
+	});
+
+	function maybe_activate_migrate_users_button() {
+		var checked = $('#affiliate-wp-migrate-user-accounts input:checkbox:checked' ).length,
+		    $button = $('#affiliate-wp-migrate-user-accounts input[type=submit]');
+
+		if ( checked > 0 ) {
+			$button.prop( 'disabled', false );
+		} else {
+			$button.prop( 'disabled', true );
+		}
+	}
+
+	maybe_activate_migrate_users_button();
+
+	$('body').on('change', '#affiliate-wp-migrate-user-accounts input:checkbox', function() {
+		maybe_activate_migrate_users_button();
+	});
+
 });

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -186,10 +186,6 @@ jQuery(document).ready(function($) {
 
 	});
 
-	$('body').on('submit', '#affiliate-wp-migrate-user-accounts input:checkbox', function(e) {
-
-	});
-
 	function maybe_activate_migrate_users_button() {
 		var checked = $('#affiliate-wp-migrate-user-accounts input:checkbox:checked' ).length,
 		    $button = $('#affiliate-wp-migrate-user-accounts input[type=submit]');

--- a/includes/admin/tools/class-migrate-base.php
+++ b/includes/admin/tools/class-migrate-base.php
@@ -1,7 +1,7 @@
 <?php
 
 class Affiliate_WP_Migrate_Base {
-	
+
 	public function __construct() { }
 
 	public function process( $step = 1, $part = '' ) {
@@ -15,18 +15,35 @@ class Affiliate_WP_Migrate_Base {
 		$part = isset( $_GET['part'] ) ? $_GET['part'] : 'affiliates';
 
 		$step++;
-		$redirect  = add_query_arg( array(
-			'page' => 'affiliate-wp-migrate',
-			'type' => 'affiliates-pro',
-			'part' => $part,
-			'step' => $step
-		), admin_url( 'index.php' ) );
-		wp_redirect( $redirect ); exit;
+
+		$redirect = add_query_arg(
+			array(
+				'page' => 'affiliate-wp-migrate',
+				'type' => 'affiliates-pro',
+				'part' => $part,
+				'step' => $step
+			),
+			admin_url( 'index.php' )
+		);
+
+		wp_safe_redirect( $redirect );
+
+		exit;
 
 	}
 
 	public function finish() {
-		wp_redirect( admin_url( 'admin.php?page=affiliate-wp' ) ); exit;
+
+		$redirect = add_query_arg(
+			array(
+				'page' => 'affiliate-wp'
+			),
+			admin_url( 'admin.php' )
+		);
+
+		wp_safe_redirect( $redirect );
+
+		exit;
 	}
 
 }

--- a/includes/admin/tools/class-migrate-users.php
+++ b/includes/admin/tools/class-migrate-users.php
@@ -12,26 +12,32 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class Affiliate_WP_Migrate_Users extends Affiliate_WP_Migrate_Base {
 
 	/**
+	 * Migrate users belonging to these roles
+	 *
+	 * @var array
+	 */
+	public $roles = array();
+
+	/**
 	 * Process the migration routine
 	 *
-	 * @since 1.3
+	 * @since  1.3
+	 * @param  int    $step
+	 * @param  string $part
+	 * @param  array  $roles (added in 1.7)
 	 * @return void
 	 */
 	public function process( $step = 1, $part = '' ) {
 
-		switch( $part ) {
+		if ( 'affiliates' !== $part || ! $this->roles ) {
+			return;
+		}
 
-			case 'affiliates' :
+		$inserted = $this->do_users( $step );
 
-				$affiliates = $this->do_users( $step );
+		if ( $inserted ) {
 
-				if( $affiliates ) {
-
-					$this->step_forward( $step, 'affiliates' );
-
-				}
-
-				break;
+			$this->step_forward( $step, 'affiliates' );
 
 		}
 
@@ -42,64 +48,107 @@ class Affiliate_WP_Migrate_Users extends Affiliate_WP_Migrate_Base {
 	/**
 	 * Move forward one step
 	 *
-	 * @since 1.3
+	 * @since  1.3
+	 * @param  int    $step
+	 * @param  string $part
 	 * @return void
 	 */
 	public function step_forward( $step = 1, $part = '' ) {
 
 		$step++;
-		$redirect  = add_query_arg( array(
-			'page' => 'affiliate-wp-migrate',
-			'type' => 'users',
-			'part' => $part,
-			'step' => $step
-		), admin_url( 'index.php' ) );
-		wp_redirect( $redirect ); exit;
+
+		$redirect = add_query_arg(
+			array(
+				'page' => 'affiliate-wp-migrate',
+				'type' => 'users',
+				'part' => $part,
+				'step' => $step
+			),
+			admin_url( 'index.php' )
+		);
+
+		wp_safe_redirect( $redirect );
+
+		exit;
 
 	}
 
 	/**
 	 * Import one batch of users
 	 *
-	 * @since 1.3
-	 * @return void
+	 * @since  1.3
+	 * @param  int     $step
+	 * @return boolean
 	 */
 	public function do_users( $step = 1 ) {
 
-		global $wpdb;
-		$offset = ($step - 1) * 100;
-		$users  = $wpdb->get_results( "SELECT * FROM $wpdb->users ORDER BY ID LIMIT $offset, 100;" );
+		if ( ! $this->roles ) {
+			return false;
+		}
 
-		if( $users ) {
-			foreach( $users as $user ) {
+		$users = new WP_User_Query(
+			array(
+				'number'     => 100,
+				'offset'     => ( $step - 1 ) * 100,
+				'orderby'    => 'ID',
+				'order'      => 'ASC',
+				'meta_query' => array(
+					array(
+						'key'     => 'wp_capabilities',
+						'value'   => sprintf( '"(%s)"', implode( '|', $this->roles ) ),
+						'compare' => 'REGEXP'
+					)
+				)
+			)
+		);
 
-				// try to get an existing affiliate based on the user_id
-				$existing_affiliate = affiliate_wp()->affiliates->get_by( 'user_id', $user->ID );
+		if ( empty( $users->results ) ) {
+			return false;
+		}
 
-				if( ! $existing_affiliate ) {
+		$inserted = array();
 
-					$args = array(
-						'status'          => 'active',
-						'user_id'         => $user->ID,
-						'payment_email'	  => $user->user_email,
-						'date_registered' => $user->user_registered,
-					);
+		foreach ( $users->results as $user ) {
 
-					//insert a new affiliate - we need to always insert to make sure the affiliate_ids will match
-					$id = affiliate_wp()->affiliates->insert( $args, 'affiliate' );
+			$affiliate_exists = affiliate_wp()->affiliates->get_by( 'user_id', $user->ID );
 
-				}
-
+			if ( $affiliate_exists ) {
+				continue;
 			}
 
-			return true;
+			$args = array(
+				'status'          => 'active',
+				'user_id'         => $user->ID,
+				'payment_email'	  => $user->user_email,
+				'date_registered' => $user->user_registered
+			);
 
-		} else {
-
-			// No users found, so all done
-			return false;
+			$inserted[] = affiliate_wp()->affiliates->insert( $args, 'affiliate' );
 
 		}
 
+		if ( ! $inserted ) {
+			return false;
+		}
+
+		return true;
+
 	}
+
+	public function finish() {
+
+		$redirect = add_query_arg(
+			array(
+				'page'         => 'affiliate-wp-affiliates',
+				'affwp_notice' => 'affiliate_added',
+			),
+			admin_url( 'admin.php' )
+		);
+
+		wp_safe_redirect( $redirect );
+
+		exit;
+
+	}
+
 }

--- a/includes/admin/tools/class-migrate-users.php
+++ b/includes/admin/tools/class-migrate-users.php
@@ -24,7 +24,6 @@ class Affiliate_WP_Migrate_Users extends Affiliate_WP_Migrate_Base {
 	 * @since  1.3
 	 * @param  int    $step
 	 * @param  string $part
-	 * @param  array  $roles (added in 1.7)
 	 * @return void
 	 */
 	public function process( $step = 1, $part = '' ) {
@@ -135,6 +134,12 @@ class Affiliate_WP_Migrate_Users extends Affiliate_WP_Migrate_Base {
 
 	}
 
+	/**
+	 * Done creating affiliate accounts for users
+	 *
+	 * @since  1.7
+	 * @return void
+	 */
 	public function finish() {
 
 		$redirect = add_query_arg(

--- a/includes/admin/tools/class-migrate.php
+++ b/includes/admin/tools/class-migrate.php
@@ -11,23 +11,26 @@ class Affiliate_WP_Migrate {
 
 	public function process_migration() {
 
-		if( empty( $_REQUEST['type'] ) ) {
+		if ( empty( $_REQUEST['type'] ) ) {
 			return false;
 		}
 
-		$step = isset( $_REQUEST['step'] ) ? absint( $_REQUEST['step'] )              : 1;
-		$type = isset( $_REQUEST['type'] ) ? sanitize_text_field( $_REQUEST['type'] ) : false;
-		$part = isset( $_REQUEST['part'] ) ? sanitize_text_field( $_REQUEST['part'] ) : false;
+		$step  = isset( $_REQUEST['step'] )  ? absint( $_REQUEST['step'] )              : 1;
+		$type  = isset( $_REQUEST['type'] )  ? sanitize_text_field( $_REQUEST['type'] ) : false;
+		$part  = isset( $_REQUEST['part'] )  ? sanitize_text_field( $_REQUEST['part'] ) : false;
+		$roles = isset( $_REQUEST['roles'] ) ? array_map( 'sanitize_text_field', explode( ',', $_REQUEST['roles'] ) ) : array();
 
-		if( ! $type ) {
+		if ( ! $type ) {
 
-			wp_redirect( admin_url() ); exit;
+			wp_safe_redirect( admin_url() );
+
+			exit;
 
 		}
 
 		require_once AFFILIATEWP_PLUGIN_DIR . 'includes/admin/tools/class-migrate-base.php';
 
-		switch( $type ) {
+		switch ( $type ) {
 
 			case 'affiliates-pro' :
 
@@ -55,6 +58,8 @@ class Affiliate_WP_Migrate {
 
 				$migrate = new Affiliate_WP_Migrate_Users;
 
+				$migrate->roles = $roles;
+
 				$migrate->process( $step, $part );
 
 				break;
@@ -64,4 +69,5 @@ class Affiliate_WP_Migrate {
 	}
 
 }
+
 new Affiliate_WP_Migrate;

--- a/includes/admin/tools/migration.php
+++ b/includes/admin/tools/migration.php
@@ -7,9 +7,11 @@
  * @return void
  */
 function affwp_migrate_admin() {
-	$step   = isset( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
-	$type   = isset( $_GET['type'] ) ? $_GET['type'] : false;
-	$part   = isset( $_GET['part'] ) ? $_GET['part'] : false;
+	$step  = isset( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
+	$type  = isset( $_GET['type'] ) ? $_GET['type'] : false;
+	$part  = isset( $_GET['part'] ) ? $_GET['part'] : false;
+	$roles = isset( $_GET['roles'] ) ? $_GET['roles'] : array();
+	$roles = is_array( $roles ) ? implode( ',', $roles ) : '';
 ?>
 	<div class="wrap">
 		<h2><?php _e( 'AffiliateWP Migration', 'affiliate-wp' ); ?></h2>
@@ -18,7 +20,7 @@ function affwp_migrate_admin() {
 			<p><strong><?php printf( __( 'Step %d running', 'affiliate-wp' ), $step ); ?>
 		</div>
 		<script type="text/javascript">
-			document.location.href = "index.php?affwp_action=migrate&step=<?php echo absint( $step ); ?>&type=<?php echo $type; ?>&part=<?php echo $part; ?>";
+			document.location.href = "index.php?affwp_action=migrate&step=<?php echo absint( $step ); ?>&type=<?php echo $type; ?>&part=<?php echo $part; ?><?php if ( 'users' === $type ) : ?>&roles=<?php echo $roles; ?><?php endif; ?>";
 		</script>
 	</div>
 <?php

--- a/includes/admin/tools/tools.php
+++ b/includes/admin/tools/tools.php
@@ -128,6 +128,15 @@ add_action( 'affwp_tools_tab_recount', 'affwp_recount_tab' );
  * @return      void
  */
 function affwp_migration_tab() {
+	$user_counts = count_users();
+
+	$_roles = new WP_Roles();
+	$roles  = array();
+
+	foreach ( $_roles->get_names() as $role => $label ) {
+		$roles[ $role ]['label'] = translate_user_role( $label );
+		$roles[ $role ]['count'] = isset( $user_counts['avail_roles'][ $role ] ) ? $user_counts['avail_roles'][ $role ] : 0;
+	}
 ?>
 	<div id="affwp-dashboard-widgets-wrap">
 		<div class="metabox-holder">
@@ -140,13 +149,23 @@ function affwp_migration_tab() {
 			<div class="postbox">
 				<h3><span><?php _e( 'User Accounts', 'affiliate-wp' ); ?></span></h3>
 				<div class="inside">
-					<p><?php _e( 'Use this tool to create affiliate accounts for each of your existing WordPress user accounts.', 'affiliate-wp' ); ?></p>
+					<p><?php _e( 'Use this tool to create affiliate accounts for each of your existing WordPress user accounts that belong to the selected roles below.', 'affiliate-wp' ); ?></p>
+					<p><?php _e( '<strong>NOTE:</strong> Users that already have affiliate accounts will be skipped. Duplicate accounts will not be created.', 'affiliate-wp' ); ?></p>
 					<form method="get">
+						<h4><span><?php _e( 'Select User Roles', 'affiliate-wp' ); ?></span></h4>
+						<?php foreach ( $roles as $role => $data ) : ?>
+							<?php $has_users = ! empty( $data['count'] ); ?>
+							<label>
+								<input type="checkbox" name="roles[]" value="<?php echo esc_attr( $role ); ?>" <?php checked( $has_users ); disabled( ! $has_users ) ?>>
+								<span class="<?php echo ( ! $has_users ) ? 'muted' : ''; ?>"><?php echo esc_html( $data['label'] ); ?> (<?php echo absint( $data['count'] ); ?>)</span>
+							</label>
+							<br>
+						<?php endforeach; ?>
 						<input type="hidden" name="type" value="users"/>
 						<input type="hidden" name="part" value="affiliates"/>
 						<input type="hidden" name="page" value="affiliate-wp-migrate"/>
 						<p>
-							<input type="submit" value="<?php _e( 'Create Affiliate Accounts', 'affiliate-wp' ); ?>" class="button"/>
+							<input type="submit" value="<?php _e( 'Create Affiliate Accounts for Users', 'affiliate-wp' ); ?>" class="button"/>
 						</p>
 					</form>
 				</div><!-- .inside -->

--- a/includes/admin/tools/tools.php
+++ b/includes/admin/tools/tools.php
@@ -151,7 +151,7 @@ function affwp_migration_tab() {
 				<div class="inside">
 					<p><?php _e( 'Use this tool to create affiliate accounts for each of your existing WordPress user accounts that belong to the selected roles below.', 'affiliate-wp' ); ?></p>
 					<p><?php _e( '<strong>NOTE:</strong> Users that already have affiliate accounts will be skipped. Duplicate accounts will not be created.', 'affiliate-wp' ); ?></p>
-					<form method="get">
+					<form method="get" id="affiliate-wp-migrate-user-accounts">
 						<h4><span><?php _e( 'Select User Roles', 'affiliate-wp' ); ?></span></h4>
 						<?php foreach ( $roles as $role => $data ) : ?>
 							<?php $has_users = ! empty( $data['count'] ); ?>
@@ -165,7 +165,7 @@ function affwp_migration_tab() {
 						<input type="hidden" name="part" value="affiliates"/>
 						<input type="hidden" name="page" value="affiliate-wp-migrate"/>
 						<p>
-							<input type="submit" value="<?php _e( 'Create Affiliate Accounts for Users', 'affiliate-wp' ); ?>" class="button"/>
+							<input type="submit" value="<?php _e( 'Create Affiliate Accounts for Users', 'affiliate-wp' ); ?>" class="button" />
 						</p>
 					</form>
 				</div><!-- .inside -->


### PR DESCRIPTION
Implements #520 

Now our users can select the roles they want to create affiliate accounts in the Migration area.

By default, all roles that contain users are automatically selected upon page load.

I've included a user count for each role for convenience, while also disabling those roles which contain no users, so they aren't even selectable.

![screen shot 2015-07-15 at 7 19 03 pm](https://cloud.githubusercontent.com/assets/522158/8712804/847c79ac-2b26-11e5-8de3-e0e811a09481.png)

If a user unchecks all the roles, the button will not be clickable. Because that's just silly.

![screen shot 2015-07-15 at 7 23 06 pm](https://cloud.githubusercontent.com/assets/522158/8712844/f50b952c-2b26-11e5-87db-7e41d99e17bd.png)

I've also improved the end process a little by redirecting the user to the Affiliates screen with the "added successfully" message.

![screen shot 2015-07-15 at 7 23 54 pm](https://cloud.githubusercontent.com/assets/522158/8712870/2f209d84-2b27-11e5-9eef-8c66ff02f069.png)
