### PR TITLE
Issue/777

### DIFF
--- a/includes/admin/affiliates/affiliates.php
+++ b/includes/admin/affiliates/affiliates.php
@@ -297,7 +297,7 @@ class AffWP_Affiliates_Table extends WP_List_Table {
 	 * @return string Displays a checkbox
 	 */
 	function column_cb( $affiliate ) {
-		return '<input type="checkbox" name="affiliate_id[]" value="' . $affiliate->affiliate_id . '" />';
+		return '<input type="checkbox" name="affiliate_id[]" value="' . absint( $affiliate->affiliate_id ) . '" />';
 	}
 
 	/**

--- a/includes/admin/affiliates/affiliates.php
+++ b/includes/admin/affiliates/affiliates.php
@@ -28,10 +28,14 @@ function affwp_affiliates_admin() {
 		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/edit.php';
 
 	} else if ( isset( $_GET['action'] ) && 'review_affiliate' == $_GET['action'] ) {
-		
+
 		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/review.php';
 
 	} else if( isset( $_GET['action'] ) && 'delete' == $_GET['action'] ) {
+
+		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/delete.php';
+
+	} else if( isset( $_GET['action2'] ) && 'delete' == $_GET['action2'] ) {
 
 		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/delete.php';
 
@@ -274,7 +278,7 @@ class AffWP_Affiliates_Table extends WP_List_Table {
 		$base         = admin_url( 'admin.php?page=affiliate-wp&affiliate_id=' . $affiliate->affiliate_id );
 		$row_actions  = array();
 		$name         = affiliate_wp()->affiliates->get_affiliate_name( $affiliate->affiliate_id );
-		
+
 		if( $name ) {
 			$name = sprintf( '<a href="%s">%s</a>', get_edit_user_link( $affiliate->user_id ), $name );
 		} else {

--- a/includes/admin/affiliates/affiliates.php
+++ b/includes/admin/affiliates/affiliates.php
@@ -17,10 +17,10 @@ function affwp_affiliates_admin() {
 
 	$action = null;
 
-	if ( isset( $_GET['action'] ) && '-1' !== $_GET['action'] ) {
-		$action = $_GET['action'];
-	} elseif ( isset( $_GET['action2'] ) && '-1' !== $_GET['action2'] ) {
+	if ( isset( $_GET['action2'] ) && '-1' !== $_GET['action2'] ) {
 		$action = $_GET['action2'];
+	} elseif ( isset( $_GET['action'] ) && '-1' !== $_GET['action'] ) {
+		$action = $_GET['action'];
 	}
 
 	if ( 'view_affiliate' === $action ) {

--- a/includes/admin/affiliates/affiliates.php
+++ b/includes/admin/affiliates/affiliates.php
@@ -15,27 +15,30 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 function affwp_affiliates_admin() {
 
-	if ( isset( $_GET['action'] ) && 'view_affiliate' == $_GET['action'] ) {
+	$action1 = isset( $_GET['action'] )  ? $_GET['action']  : null;
+	$action2 = isset( $_GET['action2'] ) ? $_GET['action2'] : null;
+
+	if ( 'view_affiliate' === $action1 ) {
 
 		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/view.php';
 
-	} else if ( isset( $_GET['action'] ) && 'add_affiliate' == $_GET['action'] ) {
+	} elseif ( 'add_affiliate' === $action1 ) {
 
 		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/new.php';
 
-	} else if ( isset( $_GET['action'] ) && 'edit_affiliate' == $_GET['action'] ) {
+	} elseif ( 'edit_affiliate' === $action1 ) {
 
 		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/edit.php';
 
-	} else if ( isset( $_GET['action'] ) && 'review_affiliate' == $_GET['action'] ) {
+	} elseif ( 'review_affiliate' === $action1 ) {
 
 		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/review.php';
 
-	} else if( isset( $_GET['action'] ) && 'delete' == $_GET['action'] ) {
-
-		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/delete.php';
-
-	} else if( isset( $_GET['action2'] ) && 'delete' == $_GET['action2'] ) {
+	} elseif (
+		( '-1' === $action2 && 'delete' === $action1 )
+		||
+		( '-1' === $action1 && 'delete' === $action2 )
+	) {
 
 		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/delete.php';
 

--- a/includes/admin/affiliates/affiliates.php
+++ b/includes/admin/affiliates/affiliates.php
@@ -15,30 +15,31 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 function affwp_affiliates_admin() {
 
-	$action1 = isset( $_GET['action'] )  ? $_GET['action']  : null;
-	$action2 = isset( $_GET['action2'] ) ? $_GET['action2'] : null;
+	$action = null;
 
-	if ( 'view_affiliate' === $action1 ) {
+	if ( isset( $_GET['action'] ) && '-1' !== $_GET['action'] ) {
+		$action = $_GET['action'];
+	} elseif ( isset( $_GET['action2'] ) && '-1' !== $_GET['action2'] ) {
+		$action = $_GET['action2'];
+	}
+
+	if ( 'view_affiliate' === $action ) {
 
 		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/view.php';
 
-	} elseif ( 'add_affiliate' === $action1 ) {
+	} elseif ( 'add_affiliate' === $action ) {
 
 		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/new.php';
 
-	} elseif ( 'edit_affiliate' === $action1 ) {
+	} elseif ( 'edit_affiliate' === $action ) {
 
 		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/edit.php';
 
-	} elseif ( 'review_affiliate' === $action1 ) {
+	} elseif ( 'review_affiliate' === $action ) {
 
 		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/review.php';
 
-	} elseif (
-		( '-1' === $action2 && 'delete' === $action1 )
-		||
-		( '-1' === $action1 && 'delete' === $action2 )
-	) {
+	} elseif ( 'delete' === $action ) {
 
 		include AFFILIATEWP_PLUGIN_DIR . 'includes/admin/affiliates/delete.php';
 


### PR DESCRIPTION
Fixes #777 

The delete affiliate bulk action now works from the bottom dropdown action.

However, I discovered another edge-case bug where:

1. The top bulk action was selected to Deactivate (or anything other than Delete)
2. The bottom bulk action was selected to Delete
3. Click on the "Apply" button next to the TOP bulk selection
4. The system would try to delete the selected affiliates

In general I think this would be somewhat rare, but I went ahead and accounted for it. So now if you want to bulk delete using either dropdown the other dropdown cannot be selecting any other action. WordPress core should really be accounting for this for us, but doesn't.