### PR TITLE
Issue/791

### DIFF
--- a/includes/admin/tools/export/class-export-affiliates.php
+++ b/includes/admin/tools/export/class-export-affiliates.php
@@ -46,6 +46,7 @@ class Affiliate_WP_Affiliate_Export extends Affiliate_WP_Export {
 		$cols = array(
 			'affiliate_id'    => __( 'Affiliate ID', 'affiliate-wp' ),
 			'email'           => __( 'Email', 'affiliate-wp' ),
+			'payment_email'   => __( 'Payment Email', 'affiliate-wp' ),
 			'username'        => __( 'Username', 'affiliate-wp' ),
 			'rate'            => __( 'Rate', 'affiliate-wp' ),
 			'rate_type'       => __( 'Rate Type', 'affiliate-wp' ),
@@ -82,6 +83,7 @@ class Affiliate_WP_Affiliate_Export extends Affiliate_WP_Export {
 				$data[] = array(
 					'affiliate_id'    => $affiliate->affiliate_id,
 					'email'           => affwp_get_affiliate_email( $affiliate->affiliate_id ),
+					'payment_email'   => affwp_get_affiliate_payment_email( $affiliate->affiliate_id ),
 					'username'        => affwp_get_affiliate_login( $affiliate->affiliate_id ),
 					'rate'            => affwp_get_affiliate_rate( $affiliate->affiliate_id ),
 					'rate_type'       => affwp_get_affiliate_rate_type( $affiliate->affiliate_id ),

--- a/includes/admin/tools/export/class-export-referrals-payout.php
+++ b/includes/admin/tools/export/class-export-referrals-payout.php
@@ -38,7 +38,6 @@ class Affiliate_WP_Referral_Payout_Export extends Affiliate_WP_Referral_Export {
 	public function csv_cols() {
 		$cols = array(
 			'email'         => __( 'Email', 'affiliate-wp' ),
-			'payment_email' => __( 'Payment Email', 'affiliate-wp' ),
 			'amount'        => __( 'Amount', 'affiliate-wp' ),
 			'currency'      => __( 'Currency', 'affiliate-wp' ),
 		);
@@ -90,10 +89,9 @@ class Affiliate_WP_Referral_Payout_Export extends Affiliate_WP_Referral_Export {
 				} else {
 
 					$data[ $referral->affiliate_id ] = array(
-						'email'         => affwp_get_affiliate_email( $referral->affiliate_id ),
-						'payment_email' => affwp_get_affiliate_payment_email( $referral->affiliate_id ),
-						'amount'        => $referral->amount,
-						'currency'      => ! empty( $referral->currency ) ? $referral->currency : affwp_get_currency()
+						'email'    => affwp_get_affiliate_payment_email( $referral->affiliate_id ),
+						'amount'   => $referral->amount,
+						'currency' => ! empty( $referral->currency ) ? $referral->currency : affwp_get_currency()
 					);
 
 					$affiliates[] = $referral->affiliate_id;

--- a/includes/admin/tools/export/class-export-referrals-payout.php
+++ b/includes/admin/tools/export/class-export-referrals-payout.php
@@ -37,9 +37,10 @@ class Affiliate_WP_Referral_Payout_Export extends Affiliate_WP_Referral_Export {
 	 */
 	public function csv_cols() {
 		$cols = array(
-			'email'    => __( 'Email', 'affiliate-wp' ),
-			'amount'   => __( 'Amount', 'affiliate-wp' ),
-			'currency' => __( 'Currency', 'affiliate-wp' ),
+			'email'         => __( 'Email', 'affiliate-wp' ),
+			'payment_email' => __( 'Payment Email', 'affiliate-wp' ),
+			'amount'        => __( 'Amount', 'affiliate-wp' ),
+			'currency'      => __( 'Currency', 'affiliate-wp' ),
 		);
 		return $cols;
 	}
@@ -88,12 +89,11 @@ class Affiliate_WP_Referral_Payout_Export extends Affiliate_WP_Referral_Export {
 
 				} else {
 
-					$email = affwp_get_affiliate_email( $referral->affiliate_id );
-
 					$data[ $referral->affiliate_id ] = array(
-						'email'    => $email,
-						'amount'   => $referral->amount,
-						'currency' => ! empty( $referral->currency ) ? $referral->currency : affwp_get_currency()
+						'email'         => affwp_get_affiliate_email( $referral->affiliate_id ),
+						'payment_email' => affwp_get_affiliate_payment_email( $referral->affiliate_id ),
+						'amount'        => $referral->amount,
+						'currency'      => ! empty( $referral->currency ) ? $referral->currency : affwp_get_currency()
 					);
 
 					$affiliates[] = $referral->affiliate_id;

--- a/includes/admin/tools/export/class-export-referrals.php
+++ b/includes/admin/tools/export/class-export-referrals.php
@@ -58,14 +58,15 @@ class Affiliate_WP_Referral_Export extends Affiliate_WP_Export {
 	 */
 	public function csv_cols() {
 		$cols = array(
-			'affiliate_id' => __( 'Affiliate ID', 'affiliate-wp' ),
-			'email'        => __( 'Email', 'affiliate-wp' ),
-			'amount'       => __( 'Amount', 'affiliate-wp' ),
-			'currency'     => __( 'Currency', 'affiliate-wp' ),
-			'reference'    => __( 'Reference', 'affiliate-wp' ),
-			'context'      => __( 'Context', 'affiliate-wp' ),
-			'status'       => __( 'Status', 'affiliate-wp' ),
-			'date'         => __( 'Date', 'affiliate-wp' )
+			'affiliate_id'  => __( 'Affiliate ID', 'affiliate-wp' ),
+			'email'         => __( 'Email', 'affiliate-wp' ),
+			'payment_email' => __( 'Payment Email', 'affiliate-wp' ),
+			'amount'        => __( 'Amount', 'affiliate-wp' ),
+			'currency'      => __( 'Currency', 'affiliate-wp' ),
+			'reference'     => __( 'Reference', 'affiliate-wp' ),
+			'context'       => __( 'Context', 'affiliate-wp' ),
+			'status'        => __( 'Status', 'affiliate-wp' ),
+			'date'          => __( 'Date', 'affiliate-wp' )
 		);
 		return $cols;
 	}
@@ -96,14 +97,15 @@ class Affiliate_WP_Referral_Export extends Affiliate_WP_Export {
 			foreach( $referrals as $referral ) {
 
 				$data[] = array(
-					'affiliate_id' => $referral->affiliate_id,
-					'email'        => affwp_get_affiliate_email( $referral->affiliate_id ),
-					'amount'       => $referral->amount,
-					'currency'     => $referral->currency,
-					'reference'    => $referral->reference,
-					'context'      => $referral->context,
-					'status'       => $referral->status,
-					'date'         => $referral->date,
+					'affiliate_id'  => $referral->affiliate_id,
+					'email'         => affwp_get_affiliate_email( $referral->affiliate_id ),
+					'payment_email' => affwp_get_affiliate_payment_email( $referral->affiliate_id ),
+					'amount'        => $referral->amount,
+					'currency'      => $referral->currency,
+					'reference'     => $referral->reference,
+					'context'       => $referral->context,
+					'status'        => $referral->status,
+					'date'          => $referral->date,
 				);
 
 			}

--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -361,34 +361,29 @@ function affwp_get_affiliate_payment_email( $affiliate, $default = false ) {
 }
 
 /**
- * Retrieves the affiliate's user_login
+ * Retrieves the affiliate's user login (username)
  *
- * @since 1.6
- * @return string
+ * @since  1.6
+ * @param  object|int $affiliate
+ * @param  mixed      $default (optional)
+ * @return mixed
  */
-function affwp_get_affiliate_login( $affiliate ) {
+function affwp_get_affiliate_login( $affiliate, $default = false ) {
 
-	global $wpdb;
+	$affiliate = is_numeric( $affiliate ) ? affwp_get_affiliate( $affiliate ) : $affiliate;
 
-	if ( is_object( $affiliate ) && isset( $affiliate->affiliate_id ) ) {
-		$affiliate_id = $affiliate->affiliate_id;
-	} elseif ( is_numeric( $affiliate ) ) {
-		$affiliate_id = absint( $affiliate );
-	} else {
-		return false;
+	if ( empty( $affiliate->affiliate_id ) ) {
+		return $default;
 	}
 
-	$affiliate = affwp_get_affiliate( $affiliate_id );
-	$user_id   = affiliate_wp()->affiliates->get_column( 'user_id', $affiliate_id );
-	$login     = $wpdb->get_var( $wpdb->prepare( "SELECT user_login FROM $wpdb->users WHERE ID = '%d'", $user_id ) );
+	$user_id = affwp_get_affiliate_user_id( $affiliate );
+	$user    = get_userdata( $user_id );
 
-	if ( $login ) {
-
-		return $login;
-
+	if ( empty( $user->user_login ) ) {
+		return $default;
 	}
 
-	return false;
+	return $user->user_login;
 
 }
 

--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -345,15 +345,14 @@ function affwp_get_affiliate_email( $affiliate, $default = false ) {
  *
  * @since  1.7
  * @param  object|int $affiliate
- * @param  mixed      $default (optional)
  * @return mixed
  */
-function affwp_get_affiliate_payment_email( $affiliate, $default = false ) {
+function affwp_get_affiliate_payment_email( $affiliate ) {
 
 	$affiliate = is_numeric( $affiliate ) ? affwp_get_affiliate( $affiliate ) : $affiliate;
 
 	if ( empty( $affiliate->payment_email ) || ! is_email( $affiliate->payment_email ) ) {
-		return $default;
+		return affwp_get_affiliate_email( $affiliate );
 	}
 
 	return $affiliate->payment_email;

--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -63,12 +63,12 @@ function affwp_get_affiliate_username( $affiliate_id = 0 ) {
 
 	if ( $affiliate ) {
 		$user_info = get_userdata( $affiliate->user_id );
-		
+
 		if ( $user_info ) {
 			$username  = esc_html( $user_info->user_login );
 			return esc_html( $username );
 		}
-		
+
 	}
 
 	return false;
@@ -316,37 +316,47 @@ function affwp_get_affiliate_rate_types() {
 /**
  * Retrieves the affiliate's email address
  *
- * @since 1.0
- * @return string
+ * @since  1.0
+ * @param  object|int $affiliate
+ * @param  mixed      $default (optional)
+ * @return mixed
  */
-function affwp_get_affiliate_email( $affiliate ) {
+function affwp_get_affiliate_email( $affiliate, $default = false ) {
 
-	global $wpdb;
+	$affiliate = is_numeric( $affiliate ) ? affwp_get_affiliate( $affiliate ) : $affiliate;
 
-	if ( is_object( $affiliate ) && isset( $affiliate->affiliate_id ) ) {
-		$affiliate_id = $affiliate->affiliate_id;
-	} elseif ( is_numeric( $affiliate ) ) {
-		$affiliate_id = absint( $affiliate );
-	} else {
-		return false;
+	if ( empty( $affiliate->affiliate_id ) ) {
+		return $default;
 	}
 
-	$affiliate   = affwp_get_affiliate( $affiliate_id );
+	$user_id = affwp_get_affiliate_user_id( $affiliate );
+	$user    = get_userdata( $user_id );
 
-	if ( ! empty( $affiliate->payment_email ) && is_email( $affiliate->payment_email ) ) {
-		$email   = $affiliate->payment_email;
-	} else {
-		$user_id = affiliate_wp()->affiliates->get_column( 'user_id', $affiliate_id );
-		$email   = $wpdb->get_var( $wpdb->prepare( "SELECT user_email FROM $wpdb->users WHERE ID = '%d'", $user_id ) );
+	if ( empty( $user->user_email ) || ! is_email( $user->user_email ) ) {
+		return $default;
 	}
 
-	if ( $email ) {
+	return $user->user_email;
 
-		return $email;
+}
 
+/**
+ * Retrieves the affiliate's payment email address
+ *
+ * @since  1.7
+ * @param  object|int $affiliate
+ * @param  mixed      $default (optional)
+ * @return mixed
+ */
+function affwp_get_affiliate_payment_email( $affiliate, $default = false ) {
+
+	$affiliate = is_numeric( $affiliate ) ? affwp_get_affiliate( $affiliate ) : $affiliate;
+
+	if ( empty( $affiliate->payment_email ) || ! is_email( $affiliate->payment_email ) ) {
+		return $default;
 	}
 
-	return false;
+	return $affiliate->payment_email;
 
 }
 
@@ -400,7 +410,7 @@ function affwp_delete_affiliate( $affiliate, $delete_data = false ) {
 	}
 
 	if( $delete_data ) {
-	
+
 		$user_id   = affwp_get_affiliate_user_id( $affiliate_id );
 		$referrals = affiliate_wp()->referrals->get_referrals( array( 'affiliate_id' => $affiliate_id, 'number' => -1 ) );
 		$visits    = affiliate_wp()->visits->get_visits( array( 'affiliate_id' => $affiliate_id, 'number' => -1 ) );
@@ -833,7 +843,7 @@ function affwp_update_affiliate( $data = array() ) {
 		if( wp_update_user( array( 'ID' => $user_id, 'user_email' => $args['account_email'] ) ) ) {
 
 			return true;
-		
+
 		}
 
 	}
@@ -920,7 +930,7 @@ function affwp_get_affiliate_referral_url( $args = array() ) {
 	} else {
 		// pretty URLs set from admin
 		$pretty = affwp_is_pretty_referral_urls();
-	} 
+	}
 
 	// get base URL
 	if ( isset( $args['base_url'] ) ) {
@@ -932,14 +942,14 @@ function affwp_get_affiliate_referral_url( $args = array() ) {
 	// add trailing slash only if no query string exists
 	if ( isset( $args['base_url'] ) && ! array_key_exists( 'query', parse_url( $base_url ) ) ) {
 		$base_url = trailingslashit( $args['base_url'] );
-	} 
+	}
 
 	// the format value, either affiliate's ID or username
 	$format_value = affwp_get_referral_format_value( $format, $affiliate_id );
 
 	// if query exists in base URL, strip it and store in variable so we can append to the end of the URL
 	if ( array_key_exists( 'query', parse_url( $base_url ) ) ) {
-		
+
 		$url_parts       = parse_url( $base_url );
 		$url_scheme      = isset( $url_parts['scheme'] ) ? $url_parts['scheme'] : 'http';
 		$url_host        = isset( $url_parts['host'] ) ? $url_parts['host'] : '';

--- a/includes/integrations/class-base.php
+++ b/includes/integrations/class-base.php
@@ -181,6 +181,17 @@ abstract class Affiliate_WP_Base {
 	}
 
 	/**
+	 * Retrieves the email address of the referring affiliate
+	 *
+	 * @access  public
+	 * @since   1.0
+	 * @return  string
+	 */
+	public function get_affiliate_email() {
+		return affwp_get_affiliate_email( $this->get_affiliate_id() );
+	}
+
+	/**
 	 * Determine if the passed email belongs to the affiliate
 	 *
 	 * Checks a given email address against the referring affiliate's

--- a/includes/integrations/class-base.php
+++ b/includes/integrations/class-base.php
@@ -27,7 +27,9 @@ abstract class Affiliate_WP_Base {
 	public function __construct() {
 
 		$this->affiliate_id = affiliate_wp()->tracking->get_affiliate_id();
+
 		$this->init();
+
 	}
 
 	/**
@@ -65,8 +67,6 @@ abstract class Affiliate_WP_Base {
 	 * @return  bool
 	 */
 	public function insert_pending_referral( $amount = '', $reference = 0, $description = '', $products = array(), $data = array() ) {
-
-		$this->affiliate_id = $this->get_affiliate_id();
 
 		if( ! (bool) apply_filters( 'affwp_integration_create_referral', true, $this->context ) ) {
 			return false; // Allow extensions to prevent referrals from being created
@@ -174,57 +174,37 @@ abstract class Affiliate_WP_Base {
 	 *
 	 * @access  public
 	 * @since   1.0
-	 * @return  string
+	 * @return  int
 	 */
 	public function get_affiliate_id() {
-		return apply_filters( 'affwp_get_referring_affiliate_id', $this->affiliate_id );
-	}
-
-	/**
-	 * Retrieves the email address of the referring affiliate
-	 *
-	 * @access  public
-	 * @since   1.0
-	 * @return  string
-	 */
-	public function get_affiliate_email() {
-		return affwp_get_affiliate_email( $this->get_affiliate_id() );
+		return absint( apply_filters( 'affwp_get_referring_affiliate_id', $this->affiliate_id ) );
 	}
 
 	/**
 	 * Determine if the passed email belongs to the affiliate
 	 *
+	 * Checks a given email address against the referring affiliate's
+	 * user email and payment email addresses to prevent customers from
+	 * referring themselves.
+	 *
 	 * @access  public
 	 * @since   1.6
+	 * @param   string $email
 	 * @return  bool
 	 */
-	public function is_affiliate_email( $email = '' ) {
+	public function is_affiliate_email( $email ) {
 
-		global $wpdb;
+		$is_affiliate_email = false;
 
-		$ret = false;
+		// Get affiliate emails
+		$user_email    = affwp_get_affiliate_email( $this->affiliate_id );
+		$payment_email = affwp_get_affiliate_payment_email( $this->affiliate_id );
 
-		$affiliate = affwp_get_affiliate( $this->affiliate_id );
+		// True if the email is valid and matches affiliate user email or payment email, otherwise false
+		$is_affiliate_email = ( is_email( $email ) && ( $user_email === $email || $payment_email === $email ) );
 
-		if ( ! empty( $affiliate->payment_email ) && is_email( $affiliate->payment_email ) ) {
+		return (bool) apply_filters( 'affwp_is_customer_email_affiliate_email', $is_affiliate_email, $email, $this->affiliate_id );
 
-			if( $email == $affiliate->payment_email ) {
-				$ret = true;
-			}
-
-		}
-
-		if( ! empty( $affiliate->user_id ) ) {
-
-			$user_email = $wpdb->get_var( $wpdb->prepare( "SELECT user_email FROM $wpdb->users WHERE ID = '%d' LIMIT 1", $affiliate->user_id ) );
-
-			if( $email == $user_email ) {
-				$ret = true;
-			}
-
-		}
-
-		return apply_filters( 'affwp_is_customer_email_affiliate_email', $ret, $email, $this->affiliate_id );
 	}
 
 	/**
@@ -237,8 +217,6 @@ abstract class Affiliate_WP_Base {
 	public function calculate_referral_amount( $base_amount = '', $reference = '', $product_id = 0 ) {
 
 		$rate = '';
-
-		$this->affiliate_id = $this->get_affiliate_id();
 
 		if( ! empty( $product_id ) ) {
 

--- a/includes/integrations/class-memberpress.php
+++ b/includes/integrations/class-memberpress.php
@@ -1,7 +1,7 @@
 <?php
 
 class Affiliate_WP_MemberPress extends Affiliate_WP_Base {
-	
+
 	/**
 	 * Get things started
 	 *
@@ -15,7 +15,7 @@ class Affiliate_WP_MemberPress extends Affiliate_WP_Base {
 		add_action( 'mepr-txn-status-pending', array( $this, 'add_pending_referral' ), 10 );
 		add_action( 'mepr-txn-status-complete', array( $this, 'mark_referral_complete' ), 10 );
 		add_action( 'mepr-txn-status-refunded', array( $this, 'revoke_referral_on_refund' ), 10 );
-	
+
 		add_filter( 'affwp_referral_reference_column', array( $this, 'reference_link' ), 10, 2 );
 
 	}
@@ -39,8 +39,9 @@ class Affiliate_WP_MemberPress extends Affiliate_WP_Base {
 
 			$user = get_userdata( $txn->user_id );
 
-			if ( $user && $this->get_affiliate_email() == $user->user_email ) {
-				return; // Customers cannot refer themselves
+			// Customers cannot refer themselves
+			if ( ! empty( $user->user_email ) && $this->is_affiliate_email( $user->user_email ) ) {
+				return;
 			}
 
 			// get referral total
@@ -77,7 +78,7 @@ class Affiliate_WP_MemberPress extends Affiliate_WP_Base {
 		}
 
 		$this->reject_referral( $txn->id );
-	
+
 	}
 
 	/**
@@ -95,7 +96,7 @@ class Affiliate_WP_MemberPress extends Affiliate_WP_Base {
 		}
 
 		$url = admin_url( 'admin.php?page=memberpress-trans&search=' . $reference );
-		
+
 		return '<a href="' . esc_url( $url ) . '">' . $reference . '</a>';
 	}
 }

--- a/templates/dashboard-tab-settings.php
+++ b/templates/dashboard-tab-settings.php
@@ -1,24 +1,33 @@
+<?php
+$affiliate_id  = affwp_get_affiliate_id();
+$user_email    = affwp_get_affiliate_email( $affiliate_id );
+$payment_email = affwp_get_affiliate_payment_email( $affiliate_id, $user_email );
+?>
+
 <div id="affwp-affiliate-dashboard-profile" class="affwp-tab-content">
 
 	<h4><?php _e( 'Profile Settings', 'affiliate-wp' ); ?></h4>
 
 	<form id="affwp-affiliate-dashboard-profile-form" class="affwp-form" method="post">
+
 		<div class="affwp-wrap affwp-payment-email-wrap">
 			<label for="affwp-payment-email"><?php _e( 'Your payment email', 'affiliate-wp' ); ?></label>
-			<input id="affwp-payment-email" type="email" name="payment_email" value="<?php echo esc_attr( affwp_get_affiliate_email( affwp_get_affiliate_id() ) ); ?>" />
+			<input id="affwp-payment-email" type="email" name="payment_email" value="<?php echo esc_attr( $payment_email ); ?>" />
 		</div>
 
 		<div class="affwp-wrap affwp-send-notifications-wrap">
-			<input id="affwp-referral-notifications" type="checkbox" name="referral_notifications" value="1"<?php checked( true, get_user_meta( affwp_get_affiliate_user_id( affwp_get_affiliate_id() ), 'affwp_referral_notifications', true ) ); ?>/>
+			<input id="affwp-referral-notifications" type="checkbox" name="referral_notifications" value="1" <?php checked( true, get_user_meta( affwp_get_affiliate_user_id( $affiliate_id ), 'affwp_referral_notifications', true ) ); ?>/>
 			<label for="affwp-referral-notifications"><?php _e( 'Enable New Referral Notifications', 'affiliate-wp' ); ?></label>
 		</div>
 
-		<?php do_action( 'affwp_affiliate_dashboard_before_submit', affwp_get_affiliate_id(), affwp_get_affiliate_user_id( affwp_get_affiliate_id() ) ); ?>
+		<?php do_action( 'affwp_affiliate_dashboard_before_submit', $affiliate_id, affwp_get_affiliate_user_id( $affiliate_id ) ); ?>
 
 		<div class="affwp-save-profile-wrap">
 			<input type="hidden" name="affwp_action" value="update_profile_settings" />
-			<input type="hidden" name="affiliate_id" value="<?php echo esc_attr( affwp_get_affiliate_id() ); ?>" />
+			<input type="hidden" name="affiliate_id" value="<?php echo absint( $affiliate_id ); ?>" />
 			<input type="submit" class="button" value="<?php esc_attr_e( 'Save Profile Settings', 'affiliate-wp' ); ?>" />
 		</div>
+
 	</form>
+
 </div>

--- a/templates/dashboard-tab-settings.php
+++ b/templates/dashboard-tab-settings.php
@@ -1,7 +1,7 @@
 <?php
 $affiliate_id  = affwp_get_affiliate_id();
 $user_email    = affwp_get_affiliate_email( $affiliate_id );
-$payment_email = affwp_get_affiliate_payment_email( $affiliate_id, $user_email );
+$payment_email = affwp_get_affiliate_payment_email( $affiliate_id, $user_email ); // Fallback to user_email
 ?>
 
 <div id="affwp-affiliate-dashboard-profile" class="affwp-tab-content">

--- a/tests/test-affiliates.php
+++ b/tests/test-affiliates.php
@@ -135,12 +135,10 @@ class Affiliate_Tests extends WP_UnitTestCase {
 	}
 
 	function test_get_affiliate_email() {
-		
-		$this->assertEquals( 'admin@example.org', affwp_get_affiliate_email( $this->_affiliate_id ) );
-		
+
 		$args = array(
 			'affiliate_id'  => $this->_affiliate_id,
-			'payment_email' => 'affiliate@test.com'
+			'account_email' => 'affiliate@test.com'
 		);
 
 		affwp_update_affiliate( $args );
@@ -148,34 +146,46 @@ class Affiliate_Tests extends WP_UnitTestCase {
 		$this->assertEquals( 'affiliate@test.com', affwp_get_affiliate_email( $this->_affiliate_id ) );
 	}
 
+	function test_get_affiliate_payment_email() {
+
+		$args = array(
+			'affiliate_id'  => $this->_affiliate_id,
+			'payment_email' => 'affiliate-payment@test.com'
+		);
+
+		affwp_update_affiliate( $args );
+
+		$this->assertEquals( 'affiliate-payment@test.com', affwp_get_affiliate_payment_email( $this->_affiliate_id ) );
+	}
+
 	function test_get_affiliate_earnings() {
-		
+
 		$this->assertEquals( 0, affwp_get_affiliate_earnings( $this->_affiliate_id ) );
-	
+
 	}
 
 	function test_get_affiliate_unpaid_earnings() {
-		
+
 		$this->assertEquals( 0, affwp_get_affiliate_unpaid_earnings( $this->_affiliate_id ) );
 		$this->assertEquals( '&#36;0', affwp_get_affiliate_unpaid_earnings( $this->_affiliate_id, true ) );
-	
+
 	}
 
 	function test_adjust_affiliate_earnings() {
-		
+
 		$this->assertEquals( 10, affwp_increase_affiliate_earnings( $this->_affiliate_id, '10' ) );
 		$this->assertFalse( affwp_increase_affiliate_earnings( 0, '10' ) );
-	
+
 		$this->assertEquals( 8, affwp_decrease_affiliate_earnings( $this->_affiliate_id, 2 ) );
 		$this->assertFalse( affwp_decrease_affiliate_earnings( 0, '10' ) );
-		
+
 		$this->assertEquals( '12.2', affwp_increase_affiliate_earnings( $this->_affiliate_id, '4.2' ) );
 	}
 
 	function test_get_affiliate_referral_count() {
-		
+
 		$this->assertEquals( 0, affwp_get_affiliate_referral_count( $this->_affiliate_id ) );
-	
+
 	}
 
 	function test_adjust_affiliate_referral_count() {
@@ -187,9 +197,9 @@ class Affiliate_Tests extends WP_UnitTestCase {
 	}
 
 	function test_get_affiliate_visit_count() {
-		
+
 		$this->assertEquals( 0, affwp_get_affiliate_visit_count( $this->_affiliate_id ) );
-	
+
 	}
 
 	function test_adjust_affiliate_visit_count() {


### PR DESCRIPTION
Resolves #791 

 * Introduces a new `affwp_get_affilaite_payment_email()` function
 * Simplified the exiting `affwp_get_affilaite_email()` function
 * Removed the `get_affiliate_email()` method from the base integrations class that was not necessary
 * Simplified the `is_affilaite_email()` method in the base integrations class
 * The `$this->affiliate_id` property was being set inside other methods but it is already assigned by the `__construct()`...I'm not sure why they were done this way, so I removed them.

Both email getter functions now have a second parameter called `$default` which is optional and defaults to `false`. The idea was to use similar behavior to `get_option()` because there may be times when you really want the payment email, but if it's not available you're OK with using the user account email, or vice versa.

**Update:** I did the same for the `affwp_get_affiliate_login()` helper function too since it was using SQL queries unnecessarily.