### PR TITLE
Issue/799

### DIFF
--- a/includes/integrations/class-gravityforms.php
+++ b/includes/integrations/class-gravityforms.php
@@ -44,7 +44,7 @@ class Affiliate_WP_Gravity_Forms extends Affiliate_WP_Base {
 
 			// Do some craziness to determine the price (this should be easy but is not)
 
-			$desc      = '';
+			$desc      = isset( $form['title'] ) ? $form['title'] : '';
 			$entry     = GFFormsModel::get_lead( $entry['id'] );
 			$products  = GFCommon::get_product_fields( $form, $entry );
 			$total     = 0;


### PR DESCRIPTION
Resolves #799 

The referral description will now default to the form title when no products exist in the form.