### PR TITLE
making sure we have a code before we check it

### DIFF
--- a/includes/integrations/class-pmp.php
+++ b/includes/integrations/class-pmp.php
@@ -221,7 +221,7 @@ class Affiliate_WP_PMP extends Affiliate_WP_Base {
 
 		$affiliate_id = false;
 
-		if( isset( $coupon_code ) && ! empty( $coupon_code ) && pmpro_checkDiscountCode( $coupon_code ) ) {
+		if( ! empty( $coupon_code ) && pmpro_checkDiscountCode( $coupon_code ) ) {
 			$table        = $wpdb->prefix . 'affiliate_wp_affiliatemeta';
 			$affiliate_id = $wpdb->get_var( $wpdb->prepare( "SELECT affiliate_id FROM $table WHERE meta_value = %s", $coupon_code ) );
 		}

--- a/includes/integrations/class-pmp.php
+++ b/includes/integrations/class-pmp.php
@@ -221,7 +221,7 @@ class Affiliate_WP_PMP extends Affiliate_WP_Base {
 
 		$affiliate_id = false;
 
-		if( pmpro_checkDiscountCode( $coupon_code ) ) {
+		if( isset( $coupon_code ) && ! empty( $coupon_code ) && pmpro_checkDiscountCode( $coupon_code ) ) {
 			$table        = $wpdb->prefix . 'affiliate_wp_affiliatemeta';
 			$affiliate_id = $wpdb->get_var( $wpdb->prepare( "SELECT affiliate_id FROM $table WHERE meta_value = %s", $coupon_code ) );
 		}


### PR DESCRIPTION
In some instances this will try and check for a coupon code when there is no code set which ends up causing PMPro to throw errors at checkout.