### PR TITLE
First pass at simple registration options on user profile

### DIFF
--- a/affiliate-wp.php
+++ b/affiliate-wp.php
@@ -313,6 +313,7 @@ final class Affiliate_WP {
 			require_once AFFILIATEWP_PLUGIN_DIR . 'includes/admin/class-welcome.php';
 			require_once AFFILIATEWP_PLUGIN_DIR . 'includes/admin/plugins.php';
 			require_once AFFILIATEWP_PLUGIN_DIR . 'includes/admin/tools/class-migrate.php';
+			require_once AFFILIATEWP_PLUGIN_DIR . 'includes/admin/user-profile.php';
 
 		}
 

--- a/includes/admin/user-profile.php
+++ b/includes/admin/user-profile.php
@@ -1,0 +1,56 @@
+<?php
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+function affwp_user_profile_fields( $user ) {
+    if( isset( $_GET['register_affiliate'] ) && 1 == absint( $_GET['register_affiliate'] ) ) {
+        $affiliate_id = affwp_add_affiliate( array( 'user_id' => $user->ID ) );
+    } else {
+        $affiliate_id = affwp_get_affiliate_id( $user->ID );
+    }
+
+    $affiliate = 0 < absint( $affiliate_id ) ? affwp_get_affiliate( $affiliate_id ) : false;
+    ?>
+    <h3><?php esc_attr_e( 'AffiliateWP', 'affiliate-wp' ); ?></h3>
+    <table class="form-table">
+        <tr>
+            <th><label><?php esc_attr_e( 'Affiliate Registration Status', 'affiliate-wp' ); ?></label></th>
+            <td>
+                <?php if( $affiliate ):
+                    switch( $affiliate->status ) {
+                        case 'active':
+                            echo '<span style="color: green; font-weight: bold;">' . esc_attr( 'Active', 'affiliate-wp' ) . '</span>';
+                            break;
+                        case 'inactive':
+                            echo '<span>' . esc_attr( 'Inactive', 'affiliate-wp' ) . '</span>';
+                            break;
+                        case 'pending':
+                            echo '<span style="color: silver;">' . esc_attr( 'Pending', 'affiliate-wp' ) . '</span>';
+                            break;
+                        case 'rejected':
+                            echo '<span style="color: red; font-weight: bold;">' . esc_attr( 'Rejected', 'affiliate-wp' ) . '</span>';
+                            break;
+                    }
+                else: ?>
+                <span style="color: red;"><?php esc_attr_e( 'Not Registered', 'affiliate-wp' ); ?></span>
+                <?php endif; ?>
+            </td>
+        </tr>
+
+        <tr>
+            <th><label><?php esc_attr_e( 'Affiliate Actions', 'affiliate-wp' ); ?></label></th>
+            <td>
+                <?php if( $affiliate ):
+                    echo '<a href="' . esc_url( add_query_arg( array( 'affwp_notice' => false, 'affiliate_id' => $affiliate->affiliate_id, 'action' => 'view_affiliate' ), admin_url( 'admin.php?page=affiliate-wp-affiliates' ) ) ) . '" class="button">' . __( 'Reports', 'affiliate-wp' ) . '</a>';
+                    echo ' ';
+                    echo '<a href="' . esc_url( add_query_arg( array( 'affwp_notice' => false, 'action' => 'edit_affiliate', 'affiliate_id' => $affiliate->affiliate_id ), admin_url( 'admin.php?page=affiliate-wp-affiliates' ) ) ) . '" class="button">' . __( 'Edit', 'affiliate-wp' ) . '</a>';
+                else: ?>
+                    <a href="<?php echo add_query_arg( array( 'user_id' => $user->ID, 'register_affiliate' => 1 ), admin_url( 'user-edit.php' ) ); ?>" class="button"><?php esc_attr_e( 'Register', 'affiliate-wp' ); ?></a>
+                <?php endif; ?>
+            </td>
+        </tr>
+    </table>
+    <?php
+}
+add_action( 'show_user_profile', 'affwp_user_profile_fields' );
+add_action( 'edit_user_profile', 'affwp_user_profile_fields' );


### PR DESCRIPTION
Sometimes (on large sites especially) adding affiliates from the default "add new" affiliates view doesn't quite work. Having an option right on the user profile could be handy and at the same time when viewing the user profile having some quick links to edit the affiliate or view ports may be useful as well.

This is a first pass at something I've already added for our own internal use. I've reworked it from our custom plugin to a part the core plugin. If it is valuable and worth merging in some feedback on how I could improve this to fit AffiliateWP better would be great and I'll update my PR. If it isn't really valuable in core... that's cool too and we'll just run with this as a separate plugin :) Just let me know!