### PR TITLE
Restore Travis Build Status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-AffiliateWP [![Build Status](https://travis-ci.org/affiliatewp/AffiliateWP.svg?branch=master)](https://travis-ci.org/affiliatewp/AffiliateWP)
+AffiliateWP [![Build Status](https://travis-ci.org/AffiliateWP/AffiliateWP.svg?branch=master)](https://travis-ci.org/AffiliateWP/AffiliateWP)
 ============
 
 AffiliateWP is a commercial plugin available from [http://affiliatewp.com](http://affiliatewp.com). The plugin is hosted here on a public Github repository in order to better faciliate community contributions from developers and users alike. If you have a suggestion, a bug report, or a patch for an issue, feel free to submit it here. We do ask, however, that if you are using the plugin on a live site that you please purchase a valid license from the [website](http://affiliatewp.com). We cannot provide support to anyone that does not hold a valid license key.


### PR DESCRIPTION
After changing the team name from to affiliatewp to AffiliateWP, we destroyed our precious badge. But, now we have a fancy badge once again.