### PR TITLE
Allow referral format to be filtered

### DIFF
--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -341,9 +341,11 @@ class Affiliate_WP_Settings {
 						'name' => __( 'Default Referral Format', 'affiliate-wp' ),
 						'desc' => sprintf( __( 'Show referral URLs to affiliates with either their affiliate ID or Username appended.<br/> For example: <strong>%s or %s</strong>.', 'affiliate-wp' ), esc_url( add_query_arg( affiliate_wp()->tracking->get_referral_var(), '1', home_url( '/' ) ) ), esc_url( add_query_arg( affiliate_wp()->tracking->get_referral_var(), $username, home_url( '/' ) ) ) ),
 						'type' => 'select',
-						'options' => array(
-							'id'       => __( 'ID', 'affiliate-wp' ),
-							'username' => __( 'Username', 'affiliate-wp' ),
+						'options' => apply_filters( 'affwp_settings_referral_format',
+							array(
+								'id'       => __( 'ID', 'affiliate-wp' ),
+								'username' => __( 'Username', 'affiliate-wp' ),
+							)
 						),
 						'std' => 'id'
 					),

--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -934,7 +934,7 @@ function affwp_get_affiliate_referral_url( $args = array() ) {
 	$args = wp_parse_args( $args, $defaults );
 
 	// get affiliate ID if passed in
-	$affiliate_id = isset( $args['affiliate_id'] ) ? $args['affiliate_id'] : '';
+	$affiliate_id = isset( $args['affiliate_id'] ) ? $args['affiliate_id'] : affwp_get_affiliate_id();
 
 	// get format, username or id
 	$format = isset( $args['format'] ) ? $args['format'] : affwp_get_referral_format();
@@ -988,7 +988,7 @@ function affwp_get_affiliate_referral_url( $args = array() ) {
 	} else {
 		$referral_url = $non_pretty_urls;
 	}
-
+	
 	return $referral_url;
 
 }

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -385,7 +385,7 @@ function affwp_get_referral_format_value( $format = '', $affiliate_id = 0 ) {
 
 	}
 
-	return $value;
+	return apply_filters( 'affwp_get_referral_format_value', $value, $format, $affiliate_id );
 }
 
 /**


### PR DESCRIPTION
New `affwp_settings_referral_format` filter that we'll need for custom affiliate slugs.