### PR TITLE
Don't skip over calculating commission

### DIFF
--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -116,7 +116,7 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 					$product_total += $product['line_tax'];
 				}
 
-				if ( $product_total <= 0 ) {
+				if ( $product_total <= 0 && 'flat' !== affwp_get_affiliate_rate_type( $affiliate_id ) ) {
 					continue;
 				}
 
@@ -125,7 +125,7 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 			}
 
 			if ( 0 == $amount && affiliate_wp()->settings->get( 'ignore_zero_referrals' ) ) {
-				
+
 				if( $this->debug ) {
 					$this->log( 'Referral not created due to 0.00 amount.' );
 				}


### PR DESCRIPTION
Fixes #1092

Prevents skipping over calculating the commission if the product is zero priced, but the affiliate has a flat rate referral type. 

A flat rate set for an affiliate should generate a flat rate referral, regardless if the product was priced at $0.00.
