### PR TITLE
Add option to disable affiliate accepted email

### DIFF
--- a/includes/class-register.php
+++ b/includes/class-register.php
@@ -391,13 +391,27 @@ class Affiliate_WP_Register {
 	 * @return void
 	 */
 	public function add_as_affiliate( $context ) {
+
+		if ( affiliate_wp()->settings->get( 'auto_register' ) ) {
+			return;
+		}
+
 		?>
 		<table id="affwp-create-affiliate" class="form-table" style="margin-top:0;">
 			<tr>
 				<th scope="row"><label for="create-affiliate-<?php echo $context; ?>"><?php _e( 'Add as Affiliate',  'affiliate-wp' ); ?></label></th>
-				<td><label for="create-affiliate-<?php echo $context; ?>"><input type="checkbox" id="create-affiliate-<?php echo $context; ?>" name="affwp_create_affiliate" value="1" /> <?php _e( 'Add the user as an affiliate.', 'affiliate-wp' ); ?></label>
+				<td>
+					<label for="create-affiliate-<?php echo $context; ?>"><input type="checkbox" id="create-affiliate-<?php echo $context; ?>" name="affwp_create_affiliate" value="1" /> <?php _e( 'Add the user as an affiliate.', 'affiliate-wp' ); ?></label>
 				</td>
 			</tr>
+			<?php if ( ! affiliate_wp()->emails->is_email_disabled() ) : ?>
+			<tr>
+				<th scope="row"><label for="disable-affiliate-email-<?php echo $context; ?>"><?php _e( 'Disable Affiliate Email',  'affiliate-wp' ); ?></label></th>
+				<td>
+					<label for="disable-affiliate-email-<?php echo $context; ?>"><input type="checkbox" id="disable-affiliate-email-<?php echo $context; ?>" name="disable_affiliate_email" value="1" /> <?php _e( 'Disable the application accepted email sent to the affiliate.', 'affiliate-wp' ); ?></label>
+				</td>
+			</tr>
+			<?php endif; ?>
 		</table>
 		<?php
 	}
@@ -411,6 +425,10 @@ class Affiliate_WP_Register {
 	 */
 	public function process_add_as_affiliate( $user_id = 0 ) {
 
+		if ( affiliate_wp()->settings->get( 'auto_register' ) ) {
+			return;
+		}
+
 		$add_affiliate     = isset( $_POST['affwp_create_affiliate'] ) ? $_POST['affwp_create_affiliate'] : '';
 		$skip_confirmation = isset( $_POST['noconfirmation'] ) ? $_POST['noconfirmation'] : '';
 
@@ -418,6 +436,10 @@ class Affiliate_WP_Register {
 			return;
 		} elseif ( ! $add_affiliate ) {
 			return;
+		}
+
+		if ( $add_affiliate && isset( $_POST['disable_affiliate_email'] ) ) {
+			add_filter( 'affwp_notify_on_approval', '__return_false' );
 		}
 
 		// add the affiliate
@@ -432,6 +454,10 @@ class Affiliate_WP_Register {
 	 * @return void
 	 */
 	function scripts() {
+
+		if ( affiliate_wp()->settings->get( 'auto_register' ) ) {
+			return;
+		}
 
 		global $pagenow;
 

--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -117,7 +117,9 @@ function affwp_notify_on_approval( $affiliate_id = 0, $status = '', $old_status 
 	$subject      = apply_filters( 'affwp_application_accepted_subject', $subject, $args );
 	$message      = apply_filters( 'affwp_application_accepted_email', $message, $args );
 
-	$emails->send( $email, $subject, $message );
+	if ( apply_filters( 'affwp_notify_on_approval', true ) ) {
+		$emails->send( $email, $subject, $message );
+	}
 
 }
 add_action( 'affwp_set_affiliate_status', 'affwp_notify_on_approval', 10, 3 );
@@ -153,7 +155,9 @@ function affwp_notify_on_pending_affiliate_registration( $affiliate_id = 0, $sta
 		$message .= __( 'We\'re currently reviewing your affiliate application and will be in touch soon!', 'affiliate-wp' ) . "\n\n";
 	}
 
-	$emails->send( $email, $subject, $message );
+	if ( apply_filters( 'affwp_notify_on_pending_affiliate_registration', true ) ) {
+		$emails->send( $email, $subject, $message );
+	}
 
 }
 add_action( 'affwp_register_user', 'affwp_notify_on_pending_affiliate_registration', 10, 3 );
@@ -189,7 +193,9 @@ function affwp_notify_on_rejected_affiliate_registration( $affiliate_id = 0, $st
 		$message .= __( 'We regret to inform you that your recent affiliate registration on {site_name} was rejected.', 'affiliate-wp' ) . "\n\n";
 	}
 
-	$emails->send( $email, $subject, $message );
+	if ( apply_filters( 'affwp_notify_on_rejected_affiliate_registration', true ) ) {
+		$emails->send( $email, $subject, $message );
+	}
 
 }
 add_action( 'affwp_set_affiliate_status', 'affwp_notify_on_rejected_affiliate_registration', 10, 3 );


### PR DESCRIPTION
#1144

Also adds 3 new email filters and prevents any of this from showing when the "Auto Register New Users" option is enabled in the affiliate settings, since this will create a new affiliate when the user is added anyway. This issue is only useful for those who have that setting off and want fine-tuned control over who gets added as an affiliate.