### PR TITLE
Add filterable helpers for retrieving the Affiliates Area page ID and URL – #1097

### DIFF
--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -1049,12 +1049,12 @@ function affwp_get_affiliate_area_page_id() {
 function affwp_get_affiliate_area_page_url( $tab = '' ) {
 	$affiliate_area_page_id = affwp_get_affiliate_area_page_id();
 
+	$affiliate_area_page_url = get_permalink( $affiliate_area_page_id );
+
 	if ( ! empty( $tab )
 		&& in_array( $tab, array( 'urls', 'stats', 'graphs', 'referrals', 'visits', 'creatives', 'settings' ) )
 	) {
-		$affiliate_area_page_url = add_query_arg( 'tab', $tab, get_permalink( $affiliate_area_page_id ) );
-	} else {
-		$affiliate_area_page_url = get_permalink( $affiliate_area_page_id );
+		$affiliate_area_page_url = add_query_arg( 'tab', $tab, $affiliate_area_page_url );
 	}
 
 	/**

--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -1018,23 +1018,23 @@ function affwp_get_affiliate_base_url() {
 }
 
 /**
- * Retrieves the page ID for the Affiliates Area page.
+ * Retrieves the page ID for the Affiliate Area page.
  *
  * @since 1.8
  *
- * @return int Affiliates Area page ID.
+ * @return int Affiliate Area page ID.
  */
-function affwp_get_affiliates_page_id() {
+function affwp_get_affiliate_area_page_id() {
 	$affiliate_page_id = affiliate_wp()->settings->get( 'affiliates_page' );
 
 	/**
-	 * Filter the Affiliates Area page ID.
+	 * Filter the Affiliate Area page ID.
 	 *
 	 * @since 1.8
 	 *
-	 * @param int $affiliate_page_id Affiliates Area page ID.
+	 * @param int $affiliate_page_id Affiliate Area page ID.
 	 */
-	return apply_filters( 'affwp_affiliates_page_id', $affiliate_page_id );
+	return apply_filters( 'affwp_affiliate_area_page_id', $affiliate_page_id );
 }
 
 /**
@@ -1043,28 +1043,28 @@ function affwp_get_affiliates_page_id() {
  * @since 1.8
  *
  * @param string $tab Optional. Tab ID. Default empty.
- * @return string If $tab is specified and valid, the URL for the given tab within the Affiliates Area page.
- *                Otherwise the Affiliates Area page URL.
+ * @return string If $tab is specified and valid, the URL for the given tab within the Affiliate Area page.
+ *                Otherwise the Affiliate Area page URL.
  */
-function affwp_get_affiliates_page_url( $tab = '' ) {
-	$affiliates_page_id = affwp_get_affiliates_page_id();
+function affwp_get_affiliate_area_page_url( $tab = '' ) {
+	$affiliate_area_page_id = affwp_get_affiliate_area_page_id();
 
 	if ( ! empty( $tab )
 		&& in_array( $tab, array( 'urls', 'stats', 'graphs', 'referrals', 'visits', 'creatives', 'settings' ) )
 	) {
-		$affiliates_page_url = add_query_arg( 'tab', $tab, get_permalink( $affiliates_page_id ) );
+		$affiliate_area_page_url = add_query_arg( 'tab', $tab, get_permalink( $affiliate_area_page_id ) );
 	} else {
-		$affiliates_page_url = get_permalink( $affiliates_page_id );
+		$affiliate_area_page_url = get_permalink( $affiliate_area_page_id );
 	}
 
 	/**
-	 * Filter the Affilates Area page URL.
+	 * Filter the Affilate Area page URL.
 	 *
 	 * @since 1.8
 	 *
-	 * @param string $affiliates_page_url Affiliates Area page URL.
-	 * @param int    $affiliates_page_id  Affiliates Area page ID.
-	 * @param string $tab                 Affiliates Area page tab (if specified).
+	 * @param string $affiliate_area_page_url Page URL.
+	 * @param int    $affiliate_area_page_id  Page ID.
+	 * @param string $tab                     Page tab (if specified).
 	 */
-	return apply_filters( 'affwp_affiliates_page_url', $affiliates_page_url, $affiliates_page_id, $tab );
+	return apply_filters( 'affwp_affiliate_area_page_url', $affiliate_area_page_url, $affiliate_area_page_id, $tab );
 }

--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -1016,3 +1016,55 @@ function affwp_get_affiliate_base_url() {
 	return apply_filters( 'affwp_affiliate_referral_url_base', $base_url );
 
 }
+
+/**
+ * Retrieves the page ID for the Affiliates Area page.
+ *
+ * @since 1.8
+ *
+ * @return int Affiliates Area page ID.
+ */
+function affwp_get_affiliates_page_id() {
+	$affiliate_page_id = affiliate_wp()->settings->get( 'affiliates_page' );
+
+	/**
+	 * Filter the Affiliates Area page ID.
+	 *
+	 * @since 1.8
+	 *
+	 * @param int $affiliate_page_id Affiliates Area page ID.
+	 */
+	return apply_filters( 'affwp_affiliates_page_id', $affiliate_page_id );
+}
+
+/**
+ * Retrieves the Affiliates Area page URL.
+ *
+ * @since 1.8
+ *
+ * @param string $tab Optional. Tab ID. Default empty.
+ * @return string If $tab is specified and valid, the URL for the given tab within the Affiliates Area page.
+ *                Otherwise the Affiliates Area page URL.
+ */
+function affwp_get_affiliates_page_url( $tab = '' ) {
+	$affiliates_page_id = affwp_get_affiliates_page_id();
+
+	if ( ! empty( $tab )
+		&& in_array( $tab, array( 'urls', 'stats', 'graphs', 'referrals', 'visits', 'creatives', 'settings' ) )
+	) {
+		$affiliates_page_url = add_query_arg( 'tab', $tab, get_permalink( $affiliates_page_id ) );
+	} else {
+		$affiliates_page_url = get_permalink( $affiliates_page_id );
+	}
+
+	/**
+	 * Filter the Affilates Area page URL.
+	 *
+	 * @since 1.8
+	 *
+	 * @param string $affiliates_page_url Affiliates Area page URL.
+	 * @param int    $affiliates_page_id  Affiliates Area page ID.
+	 * @param string $tab                 Affiliates Area page tab (if specified).
+	 */
+	return apply_filters( 'affwp_affiliates_page_url', $affiliates_page_url, $affiliates_page_id, $tab );
+}

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -1,7 +1,7 @@
 <?php
 $active_tab = ! empty( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : 'urls';
 
-$affiliates_page_id = affwp_get_affiliates_page_id();
+$affiliates_page_id = affwp_get_affiliate_area_page_id();
 ?>
 
 <div id="affwp-affiliate-dashboard">
@@ -34,25 +34,25 @@ $affiliates_page_id = affwp_get_affiliates_page_id();
 
 		<ul id="affwp-affiliate-dashboard-tabs">
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'urls' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'urls' ) ); ?>"><?php _e( 'Affiliate URLs', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliate_area_page_url( 'urls' ) ); ?>"><?php _e( 'Affiliate URLs', 'affiliate-wp' ); ?></a>
 			</li>
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'stats' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'stats' ) ); ?>"><?php _e( 'Statistics', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliate_area_page_url( 'stats' ) ); ?>"><?php _e( 'Statistics', 'affiliate-wp' ); ?></a>
 			</li>
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'graphs' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'graphs' ) ); ?>"><?php _e( 'Graphs', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliate_area_page_url( 'graphs' ) ); ?>"><?php _e( 'Graphs', 'affiliate-wp' ); ?></a>
 			</li>
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'referrals' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'referrals' ) ); ?>"><?php _e( 'Referrals', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliate_area_page_url( 'referrals' ) ); ?>"><?php _e( 'Referrals', 'affiliate-wp' ); ?></a>
 			</li>
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'visits' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'visits' ) ); ?>"><?php _e( 'Visits', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliate_area_page_url( 'visits' ) ); ?>"><?php _e( 'Visits', 'affiliate-wp' ); ?></a>
 			</li>
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'creatives' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'creatives' ) ); ?>"><?php _e( 'Creatives', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliate_area_page_url( 'creatives' ) ); ?>"><?php _e( 'Creatives', 'affiliate-wp' ); ?></a>
 			</li>
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'settings' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'settings' ) ) ); ?>"><?php _e( 'Settings', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliate_area_page_url( 'settings' ) ) ); ?>"><?php _e( 'Settings', 'affiliate-wp' ); ?></a>
 			</li>
 			<?php do_action( 'affwp_affiliate_dashboard_tabs', affwp_get_affiliate_id(), $active_tab ); ?>
 		</ul>

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -1,4 +1,8 @@
-<?php $active_tab = ! empty( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : 'urls'; ?>
+<?php
+$active_tab = ! empty( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : 'urls';
+
+$affiliates_page_id = affwp_get_affiliates_page_id();
+?>
 
 <div id="affwp-affiliate-dashboard">
 
@@ -30,25 +34,25 @@
 
 		<ul id="affwp-affiliate-dashboard-tabs">
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'urls' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( add_query_arg( 'tab', 'urls', get_permalink( affiliate_wp()->settings->get( 'affiliates_page' ) ) ) ); ?>"><?php _e( 'Affiliate URLs', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'urls' ) ); ?>"><?php _e( 'Affiliate URLs', 'affiliate-wp' ); ?></a>
 			</li>
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'stats' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( add_query_arg( 'tab', 'stats', get_permalink( affiliate_wp()->settings->get( 'affiliates_page' ) ) ) ); ?>"><?php _e( 'Statistics', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'stats' ) ); ?>"><?php _e( 'Statistics', 'affiliate-wp' ); ?></a>
 			</li>
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'graphs' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( add_query_arg( 'tab', 'graphs', get_permalink( affiliate_wp()->settings->get( 'affiliates_page' ) ) ) ); ?>"><?php _e( 'Graphs', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'graphs' ) ); ?>"><?php _e( 'Graphs', 'affiliate-wp' ); ?></a>
 			</li>
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'referrals' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( add_query_arg( 'tab', 'referrals', get_permalink( affiliate_wp()->settings->get( 'affiliates_page' ) ) ) ); ?>"><?php _e( 'Referrals', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'referrals' ) ); ?>"><?php _e( 'Referrals', 'affiliate-wp' ); ?></a>
 			</li>
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'visits' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( add_query_arg( 'tab', 'visits', get_permalink( affiliate_wp()->settings->get( 'affiliates_page' ) ) ) ); ?>"><?php _e( 'Visits', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'visits' ) ); ?>"><?php _e( 'Visits', 'affiliate-wp' ); ?></a>
 			</li>
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'creatives' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( add_query_arg( 'tab', 'creatives', get_permalink( affiliate_wp()->settings->get( 'affiliates_page' ) ) ) ); ?>"><?php _e( 'Creatives', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'creatives' ) ); ?>"><?php _e( 'Creatives', 'affiliate-wp' ); ?></a>
 			</li>
 			<li class="affwp-affiliate-dashboard-tab<?php echo $active_tab == 'settings' ? ' active' : ''; ?>">
-				<a href="<?php echo esc_url( add_query_arg( 'tab', 'settings', get_permalink( affiliate_wp()->settings->get( 'affiliates_page' ) ) ) ); ?>"><?php _e( 'Settings', 'affiliate-wp' ); ?></a>
+				<a href="<?php echo esc_url( affwp_get_affiliates_page_url( 'settings' ) ) ); ?>"><?php _e( 'Settings', 'affiliate-wp' ); ?></a>
 			</li>
 			<?php do_action( 'affwp_affiliate_dashboard_tabs', affwp_get_affiliate_id(), $active_tab ); ?>
 		</ul>

--- a/tests/test-affiliates.php
+++ b/tests/test-affiliates.php
@@ -214,5 +214,64 @@ class Affiliate_Tests extends WP_UnitTestCase {
 		$this->assertEquals( '0%', affwp_get_affiliate_conversion_rate( $this->_affiliate_id ) );
 	}
 
-}
+	/**
+	 * @covers affwp_get_affiliates_page_id()
+	 */
+	function test_get_affiliates_page_id_should_match_setting() {
+		$page_id_from_settings = affiliate_wp()->settings->get( 'affiliates_page' );
+		$this->assertSame( $page_id_from_settings, affwp_get_affiliates_page_id() );
+	}
 
+	/**
+	 * @covers affwp_get_affiliates_page_id()
+	 */
+	function test_get_affiliates_page_id_filtered_different_should_not_match_setting() {
+		$page_id_from_settings = affiliate_wp()->settings->get( 'affiliates_page' );
+
+		add_filter( 'affwp_affiliates_page_id', function() {
+			return rand( 1, 100 );
+		} );
+
+		$page_id_from_helper = affwp_get_affiliates_page_id();
+
+		$this->assertNotSame( $page_id_from_settings, $page_id_from_helper );
+	}
+
+	/**
+	 * @covers affwp_get_affiliates_page_url()
+	 */
+	function test_get_affiliates_page_url_should_match_settings() {
+		$affiliates_page_id = affwp_get_affiliates_page_id();
+
+		$this->assertSame( get_permalink( $affiliates_page_id ), affwp_get_affiliates_page_url() );
+	}
+
+	/**
+	 * @covers affwp_get_affiliates_page_url()
+	 */
+	function test_get_affiliates_page_url_with_valid_tab_should_return_tab_url() {
+		$affiliates_page_id = affwp_get_affiliates_page_id();
+
+		$tab_url = add_query_arg( 'tab', 'stats', get_permalink( $affiliates_page_id ) );
+
+		$this->assertSame( $tab_url, affwp_get_affiliates_page_url( 'stats' ) );
+	}
+
+	/**
+	 * @covers affwp_get_affiliates_page_url()
+	 */
+	function test_get_affiliates_page_url_with_invalid_tab_should_return_page_url() {
+		$affiliates_page_id = affwp_get_affiliates_page_id();
+
+		$this->assertSame( affwp_get_affiliates_page_url(), affwp_get_affiliates_page_url( 'foo' ) );
+	}
+
+	/**
+	 * @covers affwp_get_affiliates_page_url()
+	 */
+	function test_get_affiliates_page_url_with_empty_tab_should_return_page_url() {
+		$affiliates_page_id = affwp_get_affiliates_page_id();
+
+		$this->assertSame( affwp_get_affiliates_page_url(), affwp_get_affiliates_page_url( '' ) );
+	}
+}

--- a/tests/test-affiliates.php
+++ b/tests/test-affiliates.php
@@ -215,63 +215,63 @@ class Affiliate_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers affwp_get_affiliates_page_id()
+	 * @covers affwp_get_affiliate_area_page_id()
 	 */
-	function test_get_affiliates_page_id_should_match_setting() {
+	function test_get_affiliate_area_page_id_should_match_setting() {
 		$page_id_from_settings = affiliate_wp()->settings->get( 'affiliates_page' );
-		$this->assertSame( $page_id_from_settings, affwp_get_affiliates_page_id() );
+		$this->assertSame( $page_id_from_settings, affwp_get_affiliate_area_page_id() );
 	}
 
 	/**
-	 * @covers affwp_get_affiliates_page_id()
+	 * @covers affwp_get_affiliate_area_page_id()
 	 */
-	function test_get_affiliates_page_id_filtered_different_should_not_match_setting() {
+	function test_get_affiliate_area_page_id_filtered_different_should_not_match_setting() {
 		$page_id_from_settings = affiliate_wp()->settings->get( 'affiliates_page' );
 
-		add_filter( 'affwp_affiliates_page_id', function() {
+		add_filter( 'affwp_affiliate_area_page_id', function() {
 			return rand( 1, 100 );
 		} );
 
-		$page_id_from_helper = affwp_get_affiliates_page_id();
+		$page_id_from_helper = affwp_get_affiliate_area_page_id();
 
 		$this->assertNotSame( $page_id_from_settings, $page_id_from_helper );
 	}
 
 	/**
-	 * @covers affwp_get_affiliates_page_url()
+	 * @covers affwp_get_affiliate_area_page_url()
 	 */
-	function test_get_affiliates_page_url_should_match_settings() {
-		$affiliates_page_id = affwp_get_affiliates_page_id();
+	function test_get_affiliate_area_page_url_should_match_settings() {
+		$affiliates_page_id = affwp_get_affiliate_area_page_id();
 
-		$this->assertSame( get_permalink( $affiliates_page_id ), affwp_get_affiliates_page_url() );
+		$this->assertSame( get_permalink( $affiliates_page_id ), affwp_get_affiliate_area_page_url() );
 	}
 
 	/**
-	 * @covers affwp_get_affiliates_page_url()
+	 * @covers affwp_get_affiliate_area_page_url()
 	 */
-	function test_get_affiliates_page_url_with_valid_tab_should_return_tab_url() {
-		$affiliates_page_id = affwp_get_affiliates_page_id();
+	function test_get_affiliate_area_page_url_with_valid_tab_should_return_tab_url() {
+		$affiliates_page_id = affwp_get_affiliate_area_page_id();
 
 		$tab_url = add_query_arg( 'tab', 'stats', get_permalink( $affiliates_page_id ) );
 
-		$this->assertSame( $tab_url, affwp_get_affiliates_page_url( 'stats' ) );
+		$this->assertSame( $tab_url, affwp_get_affiliate_area_page_url( 'stats' ) );
 	}
 
 	/**
-	 * @covers affwp_get_affiliates_page_url()
+	 * @covers affwp_get_affiliate_area_page_url()
 	 */
-	function test_get_affiliates_page_url_with_invalid_tab_should_return_page_url() {
-		$affiliates_page_id = affwp_get_affiliates_page_id();
+	function test_get_affiliate_area_page_url_with_invalid_tab_should_return_page_url() {
+		$affiliates_page_id = affwp_get_affiliate_area_page_id();
 
-		$this->assertSame( affwp_get_affiliates_page_url(), affwp_get_affiliates_page_url( 'foo' ) );
+		$this->assertSame( affwp_get_affiliate_area_page_url(), affwp_get_affiliate_area_page_url( 'foo' ) );
 	}
 
 	/**
-	 * @covers affwp_get_affiliates_page_url()
+	 * @covers affwp_get_affiliate_area_page_url()
 	 */
-	function test_get_affiliates_page_url_with_empty_tab_should_return_page_url() {
-		$affiliates_page_id = affwp_get_affiliates_page_id();
+	function test_get_affiliate_area_page_url_with_empty_tab_should_return_page_url() {
+		$affiliates_page_id = affwp_get_affiliate_area_page_id();
 
-		$this->assertSame( affwp_get_affiliates_page_url(), affwp_get_affiliates_page_url( '' ) );
+		$this->assertSame( affwp_get_affiliate_area_page_url(), affwp_get_affiliate_area_page_url( '' ) );
 	}
 }


### PR DESCRIPTION
Significantly DRYs up templates/dashboard.php (yay!) in the process of allowing access to the page ID and URL.

Also adds some tests.

Issue: #1097
