### PR TITLE
Implement saving settings via the Affiliate_WP_Settings::set() method

### DIFF
--- a/includes/admin/class-upgrades.php
+++ b/includes/admin/class-upgrades.php
@@ -194,8 +194,8 @@ class Affiliate_WP_Upgrades {
 			$settings['referral_rate'] = floatval( $rate );
 		}
 
-		update_option( 'affwp_settings', $settings );
-
+		// Update settings.
+		affiliate_wp()->settings->set( $settings, null, $save = true );
 	}
 
 	/**
@@ -330,7 +330,8 @@ class Affiliate_WP_Upgrades {
 			unset( $settings['rejected_subject'] );
 		}
 
-		update_option( 'affwp_settings', $settings );
+		// Update settings.
+		affiliate_wp()->settings->set( $settings, null, $save = true );
 
 		$this->upgraded = true;
 

--- a/includes/admin/class-upgrades.php
+++ b/includes/admin/class-upgrades.php
@@ -195,7 +195,7 @@ class Affiliate_WP_Upgrades {
 		}
 
 		// Update settings.
-		affiliate_wp()->settings->set( $settings, null, $save = true );
+		affiliate_wp()->settings->set( $settings, $save = true );
 	}
 
 	/**
@@ -331,7 +331,7 @@ class Affiliate_WP_Upgrades {
 		}
 
 		// Update settings.
-		affiliate_wp()->settings->set( $settings, null, $save = true );
+		affiliate_wp()->settings->set( $settings, $save = true );
 
 		$this->upgraded = true;
 

--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -1029,11 +1029,7 @@ class Affiliate_WP_Settings {
 		// decode the license data
 		$license_data = json_decode( wp_remote_retrieve_body( $response ) );
 
-		$options = $this->get_all();
-
-		$options['license_status'] = $license_data->license;
-
-		update_option( 'affwp_settings', $options );
+		affiliate_wp()->settings->set( 'license_status', $license_data->license, $save = true );
 
 		delete_transient( 'affwp_license_check' );
 
@@ -1068,11 +1064,7 @@ class Affiliate_WP_Settings {
 		if ( is_wp_error( $response ) )
 			return false;
 
-		$options = $this->get_all();
-
-		$options['license_status'] = 0;
-
-		update_option( 'affwp_settings', $options );
+		affiliate_wp()->settings->set( 'license_status', 0, $save = true );
 
 		delete_transient( 'affwp_license_check' );
 
@@ -1111,11 +1103,7 @@ class Affiliate_WP_Settings {
 
 			$license_data = json_decode( wp_remote_retrieve_body( $response ) );
 
-			$options = $this->get_all();
-
-			$options['license_status'] = $license_data->license;
-
-			update_option( 'affwp_settings', $options );
+			affiliate_wp()->settings->set( 'license_status', $license_data->license, $save = true );
 
 			set_transient( 'affwp_license_check', $license_data->license, DAY_IN_SECONDS );
 

--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -1054,7 +1054,9 @@ class Affiliate_WP_Settings {
 		// decode the license data
 		$license_data = json_decode( wp_remote_retrieve_body( $response ) );
 
-		affiliate_wp()->settings->set( array( 'license_status' => $license_data->license ), $save = true );
+		affiliate_wp()->settings->set( array(
+			'license_status' => $license_data->license
+		), $save = true );
 
 		delete_transient( 'affwp_license_check' );
 
@@ -1089,7 +1091,9 @@ class Affiliate_WP_Settings {
 		if ( is_wp_error( $response ) )
 			return false;
 
-		affiliate_wp()->settings->set( array( 'license_status' => 0 ), $save = true );
+		affiliate_wp()->settings->set( array(
+			'license_status' => 0
+		), $save = true );
 
 		delete_transient( 'affwp_license_check' );
 
@@ -1128,7 +1132,9 @@ class Affiliate_WP_Settings {
 
 			$license_data = json_decode( wp_remote_retrieve_body( $response ) );
 
-			affiliate_wp()->settings->set( array( 'license_status' => $license_data->license ), $save = true );
+			affiliate_wp()->settings->set( array(
+				'license_status' => $license_data->license
+			), $save = true );
 
 			set_transient( 'affwp_license_check', $license_data->license, DAY_IN_SECONDS );
 

--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -72,11 +72,41 @@ class Affiliate_WP_Settings {
 	 * @since 1.8
 	 * @access public
 	 *
-	 * @param string $key   The option key to set.
-	 * @param mixed  $value The value to assign to the key.
+	 * @param string|array $key   The option key to set, or an array of `key => value` option pairs to set.
+	 * @param mixed        $value The value to assign to the key. Only used if `$key` is a string.
+	 * @param bool         $save  Optional. Whether to trigger saving the option or options. Default false.
+	 * @return bool If `$save` is not false, whether the options were saved successfully. True otherwise.
 	 */
-	public function set( $key, $value ) {
-		$this->options[ $key ] = $value;
+	public function set( $key, $value, $save = false ) {
+		if ( is_array( $key ) ) {
+			foreach ( $key as $option => $option_value ) {
+				$this->options[ $option ] = $option_value;
+			}
+		} else {
+			$this->options[ $key ] = $value;
+		}
+
+		if ( false !== $save ) {
+			return $this->save();
+		}
+
+		return true;
+	}
+
+	/**
+	 * Saves option values queued in memory.
+	 *
+	 * @since 1.8
+	 * @access protected
+	 *
+	 * @see Affiliate_WP_Settings::set()
+	 *
+	 * @return bool False if the options were not updated (saved) successfully, true otherwise.
+	 */
+	protected function save() {
+		$options = $this->get_all();
+
+		return update_option( 'affwp_settings', $options );
 	}
 
 	/**

--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -72,18 +72,13 @@ class Affiliate_WP_Settings {
 	 * @since 1.8
 	 * @access public
 	 *
-	 * @param string|array $key   The option key to set, or an array of `key => value` option pairs to set.
-	 * @param mixed        $value The value to assign to the key. Only used if `$key` is a string.
-	 * @param bool         $save  Optional. Whether to trigger saving the option or options. Default false.
+	 * @param array $settings An array of `key => value` setting pairs to set.
+	 * @param bool  $save     Optional. Whether to trigger saving the option or options. Default false.
 	 * @return bool If `$save` is not false, whether the options were saved successfully. True otherwise.
 	 */
-	public function set( $key, $value, $save = false ) {
-		if ( is_array( $key ) ) {
-			foreach ( $key as $option => $option_value ) {
-				$this->options[ $option ] = $option_value;
-			}
-		} else {
-			$this->options[ $key ] = $value;
+	public function set( $settings, $save = false ) {
+		foreach ( $settings as $option => $value ) {
+			$this->options[ $option ] = $value;
 		}
 
 		if ( false !== $save ) {
@@ -1059,7 +1054,7 @@ class Affiliate_WP_Settings {
 		// decode the license data
 		$license_data = json_decode( wp_remote_retrieve_body( $response ) );
 
-		affiliate_wp()->settings->set( 'license_status', $license_data->license, $save = true );
+		affiliate_wp()->settings->set( array( 'license_status' => $license_data->license ), $save = true );
 
 		delete_transient( 'affwp_license_check' );
 
@@ -1094,7 +1089,7 @@ class Affiliate_WP_Settings {
 		if ( is_wp_error( $response ) )
 			return false;
 
-		affiliate_wp()->settings->set( 'license_status', 0, $save = true );
+		affiliate_wp()->settings->set( array( 'license_status' => 0 ), $save = true );
 
 		delete_transient( 'affwp_license_check' );
 
@@ -1133,7 +1128,7 @@ class Affiliate_WP_Settings {
 
 			$license_data = json_decode( wp_remote_retrieve_body( $response ) );
 
-			affiliate_wp()->settings->set( 'license_status', $license_data->license, $save = true );
+			affiliate_wp()->settings->set( array( 'license_status' => $license_data->license ), $save = true );
 
 			set_transient( 'affwp_license_check', $license_data->license, DAY_IN_SECONDS );
 

--- a/includes/admin/tools/import/import.php
+++ b/includes/admin/tools/import/import.php
@@ -33,7 +33,7 @@ function affwp_process_settings_import() {
 	$settings = affwp_object_to_array( json_decode( file_get_contents( $import_file ) ) );
 
 	// Update settings.
-	affiliate_wp()->settings->set( $settings, null, $save = true );
+	affiliate_wp()->settings->set( $settings, $save = true );
 
 	wp_safe_redirect( admin_url( 'admin.php?page=affiliate-wp-tools&tab=export_import&affwp_notice=settings-imported' ) ); exit;
 

--- a/includes/admin/tools/import/import.php
+++ b/includes/admin/tools/import/import.php
@@ -32,7 +32,8 @@ function affwp_process_settings_import() {
 	// Retrieve the settings from the file and convert the json object to an array
 	$settings = affwp_object_to_array( json_decode( file_get_contents( $import_file ) ) );
 
-	update_option( 'affwp_settings', $settings );
+	// Update settings.
+	affiliate_wp()->settings->set( $settings, null, $save = true );
 
 	wp_safe_redirect( admin_url( 'admin.php?page=affiliate-wp-tools&tab=export_import&affwp_notice=settings-imported' ) ); exit;
 

--- a/includes/install.php
+++ b/includes/install.php
@@ -36,7 +36,7 @@ function affiliate_wp_install() {
 		);
 
 		// Update settings.
-		affiliate_wp()->settings->set( 'affiliates_page', $affiliate_area, $save = true );
+		affiliate_wp()->settings->set( array( 'affiliates_page' => $affiliate_area ), $save = true );
 	}
 
 	// 3 equals unchecked

--- a/includes/install.php
+++ b/includes/install.php
@@ -35,10 +35,8 @@ function affiliate_wp_install() {
 			)
 		);
 
-		$options = $affiliate_wp_install->settings->get_all();
-		$options['affiliates_page'] = $affiliate_area;
-		update_option( 'affwp_settings', $options );
-
+		// Update settings.
+		affiliate_wp()->settings->set( 'affiliates_page', $affiliate_area, $save = true );
 	}
 
 	// 3 equals unchecked

--- a/includes/install.php
+++ b/includes/install.php
@@ -36,7 +36,9 @@ function affiliate_wp_install() {
 		);
 
 		// Update settings.
-		affiliate_wp()->settings->set( array( 'affiliates_page' => $affiliate_area ), $save = true );
+		affiliate_wp()->settings->set( array(
+			'affiliates_page' => $affiliate_area
+		), $save = true );
 	}
 
 	// 3 equals unchecked

--- a/tests/admin/test-settings.php
+++ b/tests/admin/test-settings.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Tests for Affiliate_WP_Settings
+ *
+ * @covers Affiliate_WP_Settings
+ * @group drew
+ */
+class Afilliate_Settings_Tests extends WP_UnitTestCase {
+
+	/**
+	 * Settings instance.
+	 *
+	 * @access public
+	 * @var Affiliate_WP_Settings
+	 */
+	public $settings;
+
+	/**
+	 * Tests set up.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->settings = new Affiliate_WP_Settings();
+	}
+
+	/**
+	 * @covers Affiliate_WP_Settings::set()
+	 */
+	public function test_set_method_should_update_options_property_in_memory_only() {
+		$affiliates_area = rand( 1, 200 );
+		$this->settings->set( array( 'affiliates_page' => $affiliates_area ) );
+
+		$options = $this->settings->get_all();
+		$actual  = get_option( 'affwp_settings', array() );
+
+		$this->assertSame( $options['affiliates_page'], $affiliates_area );
+		$this->assertNotSame( $actual['affiliates_page'], $affiliates_area );
+	}
+
+	/**
+	 * @covers Affiliate_WP_Settings::set()
+	 */
+	public function test_set_method_with_save_trigger_should_update_settings() {
+		$affiliates_area = rand( 1, 200 );
+		$this->settings->set( array(
+			'affiliates_page' => $affiliates_area
+		), $save = true );
+
+		$options = $this->settings->get_all();
+		$actual  = get_option( 'affwp_settings', array() );
+
+		$this->assertSame( $options['affiliates_page'], $affiliates_area );
+		$this->assertSame( $actual['affiliates_page'], $affiliates_area );
+	}
+
+}

--- a/tests/admin/test-settings.php
+++ b/tests/admin/test-settings.php
@@ -3,7 +3,6 @@
  * Tests for Affiliate_WP_Settings
  *
  * @covers Affiliate_WP_Settings
- * @group drew
  */
 class Afilliate_Settings_Tests extends WP_UnitTestCase {
 

--- a/tests/admin/test-settings.php
+++ b/tests/admin/test-settings.php
@@ -29,7 +29,9 @@ class Afilliate_Settings_Tests extends WP_UnitTestCase {
 	 */
 	public function test_set_method_should_update_options_property_in_memory_only() {
 		$affiliates_area = rand( 1, 200 );
-		$this->settings->set( array( 'affiliates_page' => $affiliates_area ) );
+		$this->settings->set( array(
+			'affiliates_page' => $affiliates_area
+		) );
 
 		$options = $this->settings->get_all();
 		$actual  = get_option( 'affwp_settings', array() );

--- a/tests/test-misc-functions.php
+++ b/tests/test-misc-functions.php
@@ -16,7 +16,7 @@ class Misc_Functions_Tests extends WP_UnitTestCase {
 	 * @covers affwp_format_amount()
 	 */
 	public function test_affwp_format_amount_floatval_remains_floatval_with_comma_thousands_seperator() {
-		affiliate_wp()->settings->set( 'thousands_separator', ',' );
+		affiliate_wp()->settings->set( array( 'thousands_separator' => ',' ) );
 
 		add_filter( 'affwp_format_amount', function( $formatted, $amount ) {
 			$this->amount = $amount;

--- a/tests/test-misc-functions.php
+++ b/tests/test-misc-functions.php
@@ -16,7 +16,9 @@ class Misc_Functions_Tests extends WP_UnitTestCase {
 	 * @covers affwp_format_amount()
 	 */
 	public function test_affwp_format_amount_floatval_remains_floatval_with_comma_thousands_seperator() {
-		affiliate_wp()->settings->set( array( 'thousands_separator' => ',' ) );
+		affiliate_wp()->settings->set( array(
+			'thousands_separator' => ','
+		) );
 
 		add_filter( 'affwp_format_amount', function( $formatted, $amount ) {
 			$this->amount = $amount;


### PR DESCRIPTION
Issue: #1171
Related discussion: #999 

The new `Affiliate_WP_Settings::set()` method accepts an array of setting `key => value` pairs and an optional `save()` trigger.

I've implemented the `save()` method as protected, currently only to be called via the optional third parameter in `set()`. We can always switch this to public later if the need arises.

**Basic single setting usage:**
```php
		$affiliate_area = wp_insert_post(
			array(
				'post_title'     => __( 'Affiliate Area', 'affiliate-wp' ),
				'post_content'   => '[affiliate_area]',
				'post_status'    => 'publish',
				'post_author'    => 1,
				'post_type'      => 'page',
				'comment_status' => 'closed'
			)
		);

		// Update settings.
		affiliate_wp()->settings->set( array(
			'affiliates_page' => $affiliate_area
		), $save = true );
```

**Basic array of settings usage:**
```php
	// Retrieve the settings from the file and convert the json object to an array
	$settings = affwp_object_to_array( json_decode( file_get_contents( $import_file ) ) );

	// Update settings.
	affiliate_wp()->settings->set( $settings, $save = true );
```