### PR TITLE
Make Calculate Referral Amount function compatible with variable products

### DIFF
--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -119,8 +119,9 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 				if ( $product_total <= 0 && 'flat' !== affwp_get_affiliate_rate_type( $affiliate_id ) ) {
 					continue;
 				}
-
-				$amount += $this->calculate_referral_amount( $product_total, $order_id, $product['product_id'], $affiliate_id );
+				
+				$var_product_id = empty( $product->variation_id ) ? $product->id : $product->variation_id;
+				$amount += $this->calculate_referral_amount( $product_total, $order_id, $var_product_id, $affiliate_id );
 
 			}
 
@@ -214,12 +215,14 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 			} else {
 				$amount = $product['line_total'];
 			}
-
+			
+			$var_product_id = empty( $product->variation_id ) ? $product->id : $product->variation_id;
+			
 			$products[] = array(
 				'name'            => $product['name'],
 				'id'              => $product['product_id'],
 				'price'           => $amount,
-				'referral_amount' => $this->calculate_referral_amount( $amount, $order_id, $product['product_id'] )
+				'referral_amount' => $this->calculate_referral_amount( $amount, $order_id, $var_product_id )
 			);
 
 		}


### PR DESCRIPTION
Currently the parent product ID is passed to 'Affiliate_WP_Base::calculate_referral_amount()' even when the purchased product is a variable product.

This causes obvious issues when trying to filter the referral amount based on the product ID.

Affiliate_WP_Base::calculate_referral_amount() actually requires the parent ID for the 'get_product_rate' function so passing the entire product object would be a far better solution. Not sure of any implications for other integration though.

See the screen grab here of the potential issue:
[http://www.awesomescreenshot.com/image/1135225/8a5983765222d6f99fe5fa2975260aad](http://www.awesomescreenshot.com/image/1135225/8a5983765222d6f99fe5fa2975260aad)

I'm interested in hearing your thoughts.