### PR TITLE
issue/1187 – Avoid a fatal on activation by leveraging $affiliate_wp_install instead of affiliate_wp()

### DIFF
--- a/includes/install.php
+++ b/includes/install.php
@@ -36,7 +36,7 @@ function affiliate_wp_install() {
 		);
 
 		// Update settings.
-		affiliate_wp()->settings->set( array(
+		$affiliate_wp_install->settings->set( array(
 			'affiliates_page' => $affiliate_area
 		), $save = true );
 	}


### PR DESCRIPTION
Issue: #1187 