### PR TITLE
issue/1222 – Rename 'affwp_update_affiliate' action to prevent a fatal

### DIFF
--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -925,7 +925,7 @@ function affwp_update_affiliate( $data = array() ) {
 	 * @param array    $args      Prepared affiliate data.
 	 * @param array    $data      Raw affiliate data.
 	 */
-	do_action( 'affwp_update_affiliate', $affiliate, $args, $data );
+	do_action( 'affwp_pre_update_affiliate', $affiliate, $args, $data );
 
 	$updated = affiliate_wp()->affiliates->update( $affiliate_id, $args, '', 'affiliate' );
 


### PR DESCRIPTION
Issue: #1222 

Background:
'affwp_update_affilate' was introduced in 5158fba for #1073.

It conflicts with a dynamic hook fired on form submission. When the edit-affiliate form is submitted, it passes an 'update_affiliate' value to the dynamic `affwp_ . $_REQUEST['affwp_action']` hook. Causes a fatal memory exhaustion error.