### PR TITLE
WooCommerce Product totals incorrect

### DIFF
--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -209,8 +209,8 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 				continue; // Referrals are disabled on this product
 			}
 
-			if( affiliate_wp()->settings->get( 'exclude_tax' ) ) {
-				$amount = $product['line_total'] - $product['line_tax'];
+			if( !affiliate_wp()->settings->get( 'exclude_tax' ) ) {
+				$amount = $product['line_total'] + $product['line_tax'];
 			} else {
 				$amount = $product['line_total'];
 			}


### PR DESCRIPTION
Line totals never include tax so this was generating totals with the tax deducted twice when 'exclude tax' was set.

Tax should be added if 'exclude tax' is not set.
