### PR TITLE
Add a products array to the referral

### DIFF
--- a/includes/integrations/class-formidablepro.php
+++ b/includes/integrations/class-formidablepro.php
@@ -170,7 +170,9 @@ class Affiliate_WP_Formidable_Pro extends Affiliate_WP_Base {
 
 			$referral_total = $this->calculate_referral_amount( $purchase_amount, $entry_id );
 
-			$this->insert_pending_referral( $referral_total, $entry_id, $description );
+			$this->insert_pending_referral( $referral_total, $entry_id, $description, 
+			array( array('name' => 'Formidable: '.$description, 'id' => $form_id, 'price' => $purchase_amount, 'referral_amount' => $referral_total ) ) 
+			);
 
 		}
 


### PR DESCRIPTION
I am building an add-on that needs to capture and/or calculate the order total for all integrations.

My approach is to add a products array to the integrations that currently don't have one.

If there is a better approach, please let me know as I will be adding a pull request for other integrations.