### PR TITLE
issue/1343 - Add 'affwp_insert_pending_referral' filter to RCP integration

### DIFF
--- a/includes/integrations/class-rcp.php
+++ b/includes/integrations/class-rcp.php
@@ -50,6 +50,10 @@ class Affiliate_WP_RCP extends Affiliate_WP_Base {
 			$affiliate_id  = $wpdb->get_var( $wpdb->prepare( "SELECT meta_value FROM $wpdb->usermeta WHERE meta_key = %s", 'affwp_discount_rcp_' . $discount_obj->id ) );
 			$user_id       = affwp_get_affiliate_user_id( $affiliate_id );
 			$discount_aff  = get_user_meta( $user_id, 'affwp_discount_rcp_' . $discount_obj->id, true );
+			
+			$subscription_key = rcp_get_subscription_key( $user_id );
+			$subscription = rcp_get_subscription( $user_id );
+			$visit_id    = affiliate_wp()->tracking->get_visit_id();
 
 			if( $discount_aff && affiliate_wp()->tracking->is_valid_affiliate( $affiliate_id ) ) {
 
@@ -59,7 +63,7 @@ class Affiliate_WP_RCP extends Affiliate_WP_Base {
 
 				$key = get_user_meta( $user_id, 'rcp_pending_subscription_key', true );
 				if( empty( $key ) ) {
-					$key = rcp_get_subscription_key( $user_id );
+					$key = $subscription_key;
 				}
 
 				$amount = $this->calculate_referral_amount( $price, $key, absint( $_POST['rcp_level'] ) );
@@ -73,14 +77,14 @@ class Affiliate_WP_RCP extends Affiliate_WP_Base {
 					return false; // Ignore a zero amount referral
 				}
 
-				$referral_id = affiliate_wp()->referrals->add( array(
+				$referral_id = affiliate_wp()->referrals->add( apply_filters( 'affwp_insert_pending_referral', array(
 					'amount'       => $amount,
-					'reference'    => rcp_get_subscription_key( $user_id ),
-					'description'  => rcp_get_subscription( $user_id ),
+					'reference'    => $subscription_key,
+					'description'  => $subscription,
 					'affiliate_id' => $this->affiliate_id,
 					'context'      => $this->context,
 					'campaign'     => affiliate_wp()->tracking->get_campaign(),
-				) );
+				), $amount, $subscription_key, $subscription, $this->affiliate_id, $visit_id, array(), $this->context ) );
 
 			}
 
@@ -101,14 +105,13 @@ class Affiliate_WP_RCP extends Affiliate_WP_Base {
 
 			$key = get_user_meta( $user_id, 'rcp_pending_subscription_key', true );
 			if( empty( $key ) ) {
-				$key = rcp_get_subscription_key( $user_id );
+				$key = $subscription_key;
 			}
 
 			$total = $this->calculate_referral_amount( $price, $key, absint( $_POST['rcp_level'] )  );
 
-			$this->insert_pending_referral( $total, $key, rcp_get_subscription( $user_id ) );
+			$this->insert_pending_referral( $total, $key, $subscription );
 		}
-
 	}
 
 	/**


### PR DESCRIPTION
Issue: #1343

This will bring the integration inline with all other integrations who use this filter.

Could also just use 'insert_pending_referral()' here which fires the filter ?????

I have not tested this.
I am developing an add-on that requires the filter and noticed it was missing for this integration.

