### PR TITLE
issue/1355 – Globally remove referral bits from pagination URLs

### DIFF
--- a/includes/class-tracking.php
+++ b/includes/class-tracking.php
@@ -54,6 +54,7 @@ class Affiliate_WP_Tracking {
 		add_action( 'wp_ajax_affwp_check_js', array( $this, 'check_js' ) );
 		add_action( 'wp_ajax_nopriv_affwp_check_js', array( $this, 'check_js' ) );
 
+		add_filter( 'paginate_links', array( $this, 'strip_referral_from_paged_urls' ), 100 );
 	}
 
 	/**
@@ -744,4 +745,37 @@ class Affiliate_WP_Tracking {
 		
 	}
 
+	/**
+	 * Strips pretty referral bits from pagination links.
+	 *
+	 * @since 1.9
+	 * @access public
+	 *
+	 * @param string $link Pagination link.
+	 * @return string (Maybe) filtered pagination link.
+	 */
+	public function strip_referral_from_paged_urls( $link ) {
+		if ( ! is_paged() ) {
+			return $link;
+		}
+
+		// Only mess with $link if there's pagination.
+		preg_match( '/page\/\d\//', $link, $matches );
+
+		if ( ! empty( $matches[0] ) ) {
+			$referral_var = $this->get_referral_var();
+
+			// Remove a non-pretty referral ID.
+			$link = remove_query_arg( $referral_var, $link );
+
+			// Remove a pretty referral ID or username.
+			preg_match( "/$referral_var\/(\w+)\//", $link, $pretty_matches );
+
+			if ( ! empty( $pretty_matches[0] ) ) {
+				$link = str_replace( $pretty_matches[0], '', $link );
+			}
+		}
+
+		return $link;
+	}
 }

--- a/includes/class-tracking.php
+++ b/includes/class-tracking.php
@@ -760,7 +760,7 @@ class Affiliate_WP_Tracking {
 		}
 
 		// Only mess with $link if there's pagination.
-		preg_match( '/page\/\d\//', $link, $matches );
+		preg_match( '/page\/\d\/?/', $link, $matches );
 
 		if ( ! empty( $matches[0] ) ) {
 			$referral_var = $this->get_referral_var();

--- a/includes/class-tracking.php
+++ b/includes/class-tracking.php
@@ -755,10 +755,6 @@ class Affiliate_WP_Tracking {
 	 * @return string (Maybe) filtered pagination link.
 	 */
 	public function strip_referral_from_paged_urls( $link ) {
-		if ( ! is_paged() ) {
-			return $link;
-		}
-
 		// Only mess with $link if there's pagination.
 		preg_match( '/page\/\d\/?/', $link, $matches );
 

--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -563,8 +563,10 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 		preg_match( '/page\/\d\//', $link, $matches );
 
 		if ( ! empty( $matches[0] ) ) {
+			$referral_var = affiliate_wp()->tracking->get_referral_var();
+
 			// Remove a non-pretty referral ID.
-			$link = remove_query_arg( affiliate_wp()->tracking->get_referral_var(), $link );
+			$link = remove_query_arg( $referral_var, $link );
 
 			// Remove a pretty referral ID or username.
 			preg_match( "/$referral_var\/(\w+)\//", $link, $pretty_matches );

--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -49,8 +49,6 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 
 		// Shop page.
 		add_action( 'pre_get_posts', array( $this, 'force_shop_page_for_referrals' ), 5 );
-		add_filter( 'paginate_links', array( $this, 'strip_referral_from_paged_urls' ), 100 );
-
 	}
 
 	/**
@@ -548,35 +546,15 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 	 *
 	 * @since 1.8
 	 * @since 1.8.1 Skipped for product taxonomies and searches
-	 * @since 1.8.3 Restructured to remove any kind of referral values
+	 * @deprecated 1.8.3
+	 * @see Affiliate_WP_Tracking::strip_referral_from_paged_urls()
 	 * @access public
 	 *
 	 * @param string $link Pagination link.
 	 * @return string (Maybe) filtered pagination link.
 	 */
 	public function strip_referral_from_paged_urls( $link ) {
-		if ( ( ! is_shop() && ! is_paged() ) ) {
-			return $link;
-		}
-
-		// Only mess with $link if there's pagination.
-		preg_match( '/page\/\d\//', $link, $matches );
-
-		if ( ! empty( $matches[0] ) ) {
-			$referral_var = affiliate_wp()->tracking->get_referral_var();
-
-			// Remove a non-pretty referral ID.
-			$link = remove_query_arg( $referral_var, $link );
-
-			// Remove a pretty referral ID or username.
-			preg_match( "/$referral_var\/(\w+)\//", $link, $pretty_matches );
-
-			if ( ! empty( $pretty_matches[0] ) ) {
-				$link = str_replace( $pretty_matches[0], '', $link );
-			}
-		}
-
-		return $link;
+		return affiliate_wp()->tracking->strip_referral_from_paged_urls( $link );
 	}
 
 }

--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -548,13 +548,14 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 	 *
 	 * @since 1.8
 	 * @since 1.8.1 Skipped for product taxonomies and searches
+	 * @since 1.8.3 Restructured to remove any kind of referral values
 	 * @access public
 	 *
 	 * @param string $link Pagination link.
 	 * @return string (Maybe) filtered pagination link.
 	 */
 	public function strip_referral_from_paged_urls( $link ) {
-		if ( ( ! is_shop() && ! is_paged() ) || is_product_taxonomy() || is_search() ) {
+		if ( ( ! is_shop() && ! is_paged() ) ) {
 			return $link;
 		}
 

--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -558,12 +558,18 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 			return $link;
 		}
 
-		$pagination = preg_match( '/page\/\d\//', $link, $matches );
+		// Only mess with $link if there's pagination.
+		preg_match( '/page\/\d\//', $link, $matches );
 
 		if ( ! empty( $matches[0] ) ) {
-			$base = get_permalink( wc_get_page_id( 'shop' ) );
-			if ( $base ) {
-				$link = esc_url( trailingslashit( $base ) . $matches[0] );
+			// Remove a non-pretty referral ID.
+			$link = remove_query_arg( affiliate_wp()->tracking->get_referral_var(), $link );
+
+			// Remove a pretty referral ID or username.
+			preg_match( "/$referral_var\/(\w+)\//", $link, $pretty_matches );
+
+			if ( ! empty( $pretty_matches[0] ) ) {
+				$link = str_replace( $pretty_matches[0], '', $link );
 			}
 		}
 

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -8,20 +8,9 @@
 class Tracking_Tests extends WP_UnitTestCase {
 
 	/**
-	 * Tear down.
-	 */
-	public function tearDown() {
-		$GLOBALS['wp_query']->is_paged = false;
-
-		parent::tearDown();
-	}
-
-	/**
 	 * @covers Affiliate_WP_Tracking::strip_referral_from_paged_urls()
 	 */
 	public function test_strip_referral_from_paged_urls_should_remove_query_string_referral_vars() {
-		$this->is_paged();
-
 		$referral_var = affiliate_wp()->tracking->get_referral_var();
 		$url          = WP_TESTS_DOMAIN . "/foobar/page/2/?{$referral_var}=2";
 
@@ -34,23 +23,11 @@ class Tracking_Tests extends WP_UnitTestCase {
 	 * @covers Affiliate_WP_Tracking::strip_referral_from_paged_urls()
 	 */
 	public function test_strip_referral_from_paged_urls_should_remove_pretty_referral_vars() {
-		$this->is_paged();
-
 		$referral_var = affiliate_wp()->tracking->get_referral_var();
 		$url          = WP_TESTS_DOMAIN . "/foobar/{$referral_var}/2/page/3/";
 
 		$stripped = affiliate_wp()->tracking->strip_referral_from_paged_urls( $url );
 
 		$this->assertSame( WP_TESTS_DOMAIN . '/foobar/page/3/', $stripped );
-	}
-
-	/**
-	 * Set is_paged() to true.
-	 *
-	 * @since 1.9
-	 * @access public
-	 */
-	public function is_paged() {
-		$GLOBALS['wp_query']->is_paged = true;
 	}
 }

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Tests for Affiliate_WP_Tracking.
+ *
+ * @covers Affiliate_WP_Tracking
+ * @group tracking
+ */
+class Tracking_Tests extends WP_UnitTestCase {
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown() {
+		$GLOBALS['wp_query']->is_paged = false;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers Affiliate_WP_Tracking::strip_referral_from_paged_urls()
+	 */
+	public function test_strip_referral_from_paged_urls_should_remove_query_string_referral_vars() {
+		$this->is_paged();
+
+		$referral_var = affiliate_wp()->tracking->get_referral_var();
+		$url          = WP_TESTS_DOMAIN . "/foobar/page/2/?{$referral_var}=2";
+
+		// Non-trailing slashed:
+		$stripped = affiliate_wp()->tracking->strip_referral_from_paged_urls( $url );
+		$this->assertSame( WP_TESTS_DOMAIN . '/foobar/page/2/', $stripped );
+	}
+
+	/**
+	 * @covers Affiliate_WP_Tracking::strip_referral_from_paged_urls()
+	 */
+	public function test_strip_referral_from_paged_urls_should_remove_pretty_referral_vars() {
+		$this->is_paged();
+
+		$referral_var = affiliate_wp()->tracking->get_referral_var();
+		$url          = WP_TESTS_DOMAIN . "/foobar/{$referral_var}/2/page/3/";
+
+		$stripped = affiliate_wp()->tracking->strip_referral_from_paged_urls( $url );
+
+		$this->assertSame( WP_TESTS_DOMAIN . '/foobar/page/3/', $stripped );
+	}
+
+	/**
+	 * Set is_paged() to true.
+	 *
+	 * @since 1.9
+	 * @access public
+	 */
+	public function is_paged() {
+		$GLOBALS['wp_query']->is_paged = true;
+	}
+}


### PR DESCRIPTION
Issue: #1355

Previously, the start-from-scratch approach simply matched for referral and pagination URLs and rebuilt the pagination URLs from scratch, making the assumption no other variables would be in play. This dangerous assumption spawned many edge cases since it was introduced.

The new approach serves to actually try to remove both pretty and ugly referral IDs and usernames from `$link`, accounting for other variables possibly in play in the pagination URLs.