### PR TITLE
issue/1450 – Statically define $db_group at the object level, avoiding memory gymnastics

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -617,10 +617,9 @@ function affwp_clean_item_cache( $object ) {
 		return false;
 	}
 
-	$Object_Class      = get_class( $object );
-	$cache_key         = $Object_Class::get_cache_key( $object->ID );
-	$cache_group       = $Object_Class::$object_type;
-	$query_cache_group = $Object_Class::$object_group;
+	$Object_Class = get_class( $object );
+	$cache_key    = $Object_Class::get_cache_key( $object->ID );
+	$cache_group  = $Object_Class::$object_type;
 
 	// Individual object.
 	wp_cache_delete( $cache_key, $cache_group );
@@ -629,5 +628,5 @@ function affwp_clean_item_cache( $object ) {
 	$Object_Class::get_instance( $object->ID );
 
 	// last_changed for queries.
-	wp_cache_set( 'last_changed', microtime(), $query_cache_group );
+	wp_cache_set( 'last_changed', microtime(), $Object_Class::$db_group );
 }

--- a/includes/objects/class-affwp-affiliate.php
+++ b/includes/objects/class-affwp-affiliate.php
@@ -130,6 +130,17 @@ final class Affiliate extends Object {
 	public static $cache_token = 'affwp_affiliates';
 
 	/**
+	 * Database group.
+	 *
+	 * Used in \AffWP\Object for accessing the affiliates DB class methods.
+	 *
+	 * @since 1.9
+	 * @access public
+	 * @var string
+	 */
+	public static $db_group = 'affiliates';
+
+	/**
 	 * Object type.
 	 *
 	 * Used as the cache group and for accessing object DB classes in the parent.
@@ -199,22 +210,6 @@ final class Affiliate extends Object {
 		}
 
 		return $value;
-	}
-
-	/**
-	 * Retrieves the object instance.
-	 *
-	 * @since 1.9
-	 * @access public
-	 * @static
-	 *
-	 * @param int $object Object ID.
-	 * @return object|false Object instance or false.
-	 */
-	public static function get_instance( $object_id ) {
-		self::$object_group = affiliate_wp()->affiliates->cache_group;
-
-		return parent::get_instance( $object_id );
 	}
 
 	/**

--- a/includes/objects/class-affwp-creative.php
+++ b/includes/objects/class-affwp-creative.php
@@ -107,6 +107,17 @@ final class Creative extends Object {
 	public static $cache_token = 'affwp_creatives';
 
 	/**
+	 * Database group.
+	 *
+	 * Used in \AffWP\Object for accessing the creatives DB class methods.
+	 *
+	 * @since 1.9
+	 * @access public
+	 * @var string
+	 */
+	public static $db_group = 'creatives';
+
+	/**
 	 * Object type.
 	 *
 	 * Used as the cache group and for accessing object DB classes in the parent.
@@ -134,22 +145,6 @@ final class Creative extends Object {
 			$value = (int) $value;
 		}
 		return $value;
-	}
-
-	/**
-	 * Retrieves the object instance.
-	 *
-	 * @since 1.9
-	 * @access public
-	 * @static
-	 *
-	 * @param int $object Object ID.
-	 * @return object|false Object instance or false.
-	 */
-	public static function get_instance( $object_id ) {
-		self::$object_group = affiliate_wp()->creatives->cache_group;
-
-		return parent::get_instance( $object_id );
 	}
 
 }

--- a/includes/objects/class-affwp-object.php
+++ b/includes/objects/class-affwp-object.php
@@ -28,18 +28,6 @@ abstract class Object {
 	protected $filled = null;
 
 	/**
-	 * Object group.
-	 *
-	 * Should be initialized in extending class versions of get_instance().
-	 *
-	 * @since 1.9
-	 * @access public
-	 * @static
-	 * @var string
-	 */
-	public static $object_group;
-
-	/**
 	 * Retrieves the object instance.
 	 *
 	 * @since 1.9
@@ -54,15 +42,14 @@ abstract class Object {
 			return false;
 		}
 
-		$Sub_Class    = get_called_class();
-		$cache_key    = self::get_cache_key( $object_id );
-		$cache_group  = static::$object_type;
-		$object_group = static::$object_group;
+		$Sub_Class   = get_called_class();
+		$cache_key   = self::get_cache_key( $object_id );
+		$cache_group = static::$object_type;
 
 		$_object = wp_cache_get( $cache_key, $cache_group );
 
 		if ( false === $_object ) {
-			$_object = affiliate_wp()->{$object_group}->get( $object_id );
+			$_object = affiliate_wp()->{static::$db_group}->get( $object_id );
 
 			if ( ! $_object ) {
 				return false;
@@ -118,8 +105,7 @@ abstract class Object {
 	 */
 	public function __get( $key ) {
 		if ( 'ID' === $key ) {
-			$object_group = static::$object_group;
-			$primary_key  = affiliate_wp()->{$object_group}->primary_key;
+			$primary_key  = affiliate_wp()->{static::$db_group}->primary_key;
 
 			return $this->{$primary_key};
 		}
@@ -186,12 +172,7 @@ abstract class Object {
 	 * @return bool True on success, false on failure.
 	 */
 	public function save() {
-		// Refresh the instance before save.
-		static::get_instance( $this->ID );
-
-		$Sub_Class    = get_called_class();
-		$object_type  = $Sub_Class::$object_type;
-		$object_group = $Sub_Class::$object_group;
+		$object_type = static::$object_type;
 
 		switch ( $object_type ) {
 			case 'referral':
@@ -203,7 +184,8 @@ abstract class Object {
 				break;
 
 			default:
-				$updated = affiliate_wp()->{$object_group}->update( $this->ID, $this->to_array(), '', $object_type );
+				// Affiliates and Creatives have update() methods.
+				$updated = affiliate_wp()->{static::$db_group}->update( $this->ID, $this->to_array(), '', $object_type );
 				break;
 		}
 

--- a/includes/objects/class-affwp-referral.php
+++ b/includes/objects/class-affwp-referral.php
@@ -152,6 +152,17 @@ final class Referral extends Object {
 	public static $cache_token = 'affwp_referrals';
 
 	/**
+	 * Database group.
+	 *
+	 * Used in \AffWP\Object for accessing the referrals DB class methods.
+	 *
+	 * @since 1.9
+	 * @access public
+	 * @var string
+	 */
+	public static $db_group = 'referrals';
+
+	/**
 	 * Object type.
 	 *
 	 * Used as the cache group and for accessing object DB classes in the parent.
@@ -179,22 +190,6 @@ final class Referral extends Object {
 			$value = (int) $value;
 		}
 		return $value;
-	}
-
-	/**
-	 * Retrieves the object instance.
-	 *
-	 * @since 1.9
-	 * @access public
-	 * @static
-	 *
-	 * @param int $object Object ID.
-	 * @return object|false Object instance or false.
-	 */
-	public static function get_instance( $object_id ) {
-		self::$object_group = affiliate_wp()->referrals->cache_group;
-
-		return parent::get_instance( $object_id );
 	}
 
 }

--- a/includes/objects/class-affwp-visit.php
+++ b/includes/objects/class-affwp-visit.php
@@ -107,6 +107,17 @@ final class Visit extends Object {
 	public static $cache_token = 'affwp_visits';
 
 	/**
+	 * Database group.
+	 *
+	 * Used in \AffWP\Object for accessing the visits DB class methods.
+	 *
+	 * @since 1.9
+	 * @access public
+	 * @var string
+	 */
+	public static $db_group = 'visits';
+
+	/**
 	 * Object type.
 	 *
 	 * Used as the cache group and for accessing object DB classes in the parent.
@@ -134,22 +145,6 @@ final class Visit extends Object {
 			$value = (int) $value;
 		}
 		return $value;
-	}
-
-	/**
-	 * Retrieves the object instance.
-	 *
-	 * @since 1.9
-	 * @access public
-	 * @static
-	 *
-	 * @param int $object Object ID.
-	 * @return object|false Object instance or false.
-	 */
-	public static function get_instance( $object_id ) {
-		self::$object_group = affiliate_wp()->visits->cache_group;
-
-		return parent::get_instance( $object_id );
 	}
 
 }


### PR DESCRIPTION
Issue: #1450 
Related: #1184, #854 

Instead of trying to make the `$cache_group` in the db classes all things to all classes, statically define `$db_group` at the individual object level for use by the base `\Object` class. Allows us to avoid gymnastics such as dynamically populating the formerly-used `$object_group` when `get_instance()` was  called at the object level. The `$object_group` was able to get polluted because of how it was generated and when.

This approach gives us long term flexibility.