### PR TITLE
Allow docs dir into core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ $RECYCLE.BIN/
 /vendor/
 composer.lock
 /build/
-docs


### PR DESCRIPTION
- Removes `/docs` from ignore list.

- Addresses #1643