### PR TITLE
issue/1656 – Adjust affwp_get_affiliate_rate() to fail gracefully via the filter

### DIFF
--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -315,6 +315,7 @@ function affwp_get_affiliate_rate( $affiliate = 0, $formatted = false, $product_
 	$default_rate = affiliate_wp()->settings->get( 'referral_rate', 20 );
 	$default_rate = affwp_abs_number_round( $default_rate );
 
+	// Back-compat for optional $affiliate.
 	if ( ! $affiliate = affwp_get_affiliate( $affiliate ) ) {
 		$affiliate_id   = 0;
 		$affiliate_rate = null;

--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -311,13 +311,21 @@ function affwp_get_affiliate_status_label( $affiliate = 0 ) {
  */
 function affwp_get_affiliate_rate( $affiliate = 0, $formatted = false, $product_rate = '', $reference = '' ) {
 
-	if ( ! $affiliate = affwp_get_affiliate( $affiliate ) ) {
-		return '';
-	}
-
 	// Global referral rate setting, fallback to 20
 	$default_rate = affiliate_wp()->settings->get( 'referral_rate', 20 );
 	$default_rate = affwp_abs_number_round( $default_rate );
+
+	if ( ! $affiliate = affwp_get_affiliate( $affiliate ) ) {
+		$type = affiliate_wp()->settings->get( 'referral_rate_type', 'percentage' );
+
+		if ( $formatted ) {
+			$default_rate = ( 'percentage' === $type ) ? $default_rate / 100 : $default_rate;
+			$default_rate = affwp_format_rate( $default_rate );
+		}
+
+		/** This filter is documented in includes/affiliate-functions.php */
+		return apply_filters( 'affwp_get_affiliate_rate', $default_rate, $affiliate, $type, $reference );
+	}
 
 	// Get product-specific referral rate, fallback to global rate
 	$product_rate = affwp_abs_number_round( $product_rate );

--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -316,15 +316,11 @@ function affwp_get_affiliate_rate( $affiliate = 0, $formatted = false, $product_
 	$default_rate = affwp_abs_number_round( $default_rate );
 
 	if ( ! $affiliate = affwp_get_affiliate( $affiliate ) ) {
-		$type = affiliate_wp()->settings->get( 'referral_rate_type', 'percentage' );
-
-		if ( $formatted ) {
-			$default_rate = ( 'percentage' === $type ) ? $default_rate / 100 : $default_rate;
-			$default_rate = affwp_format_rate( $default_rate );
-		}
-
-		/** This filter is documented in includes/affiliate-functions.php */
-		return apply_filters( 'affwp_get_affiliate_rate', $default_rate, $affiliate, $type, $reference );
+		$affiliate_id   = 0;
+		$affiliate_rate = null;
+	} else {
+		$affiliate_id   = $affiliate->ID;
+		$affiliate_rate = $affiliate->rate();
 	}
 
 	// Get product-specific referral rate, fallback to global rate
@@ -332,12 +328,11 @@ function affwp_get_affiliate_rate( $affiliate = 0, $formatted = false, $product_
 	$product_rate = ( null !== $product_rate ) ? $product_rate : $default_rate;
 
 	// Get rate in order of priority: Affiliate -> Product -> Global
-	$rate = affwp_abs_number_round( $affiliate->rate() );
-
-	$rate = $affiliate->has_custom_rate() ? $rate : $product_rate;
+	$rate = affwp_abs_number_round( $affiliate_rate );
+	$rate = ( null !== $rate ) ? $rate : $product_rate;
 
 	// Get the referral rate type.
-	$type = $affiliate->rate_type();
+	$type = affwp_get_affiliate_rate_type( $affiliate_id );
 
 	// Format percentage rates
 	$rate = ( 'percentage' === $type ) ? $rate / 100 : $rate;
@@ -349,7 +344,7 @@ function affwp_get_affiliate_rate( $affiliate = 0, $formatted = false, $product_
 	 * @param  int     $affiliate_id
 	 * @param  string  $type
 	 */
-	$rate = (string) apply_filters( 'affwp_get_affiliate_rate', $rate, $affiliate->ID, $type, $reference );
+	$rate = (string) apply_filters( 'affwp_get_affiliate_rate', $rate, $affiliate_id, $type, $reference );
 
 	// Return rate now if formatting is not required
 	if ( ! $formatted ) {

--- a/tests/affiliates/test-affiliate-functions.php
+++ b/tests/affiliates/test-affiliate-functions.php
@@ -429,6 +429,32 @@ class Tests extends UnitTestCase {
 	}
 
 	/**
+	 * @covers ::affwp_get_affiliate_rate()
+	 */
+	public function test_get_affiliate_rate_with_invalid_affiliate_id_and_product_rate_should_default_to_product_rate() {
+		$default_type = affiliate_wp()->settings->get( 'referral_rate_type', 'percentage' );
+
+		if ( 'percentage' === affiliate_wp()->settings->get( 'referral_rate_type', 'percentage' ) ) {
+			$product_rate = 0.3;
+		}
+
+		$this->assertEquals( $product_rate, affwp_get_affiliate_rate( 0, false, 30 ) );
+	}
+
+	/**
+	 * @covers ::affwp_get_affiliate_rate()
+	 */
+	public function test_get_affiliate_rate_with_invalid_affiliate_object_and_product_rate_should_default_to_product_rate() {
+		$default_type = affiliate_wp()->settings->get( 'referral_rate_type', 'percentage' );
+
+		if ( 'percentage' === affiliate_wp()->settings->get( 'referral_rate_type', 'percentage' ) ) {
+			$product_rate = 0.3;
+		}
+
+		$this->assertEquals( $product_rate, affwp_get_affiliate_rate( new \stdClass(), false, 30 ) );
+	}
+
+	/**
 	 * @covers ::affwp_affiliate_has_custom_rate()
 	 */
 	public function test_affiliate_has_custom_rate_passed_an_invalid_affiliate_id_should_always_return_false() {

--- a/tests/affiliates/test-affiliate-functions.php
+++ b/tests/affiliates/test-affiliate-functions.php
@@ -376,15 +376,46 @@ class Tests extends UnitTestCase {
 	/**
 	 * @covers ::affwp_get_affiliate_rate()
 	 */
-	public function test_get_affiliate_rate_should_return_empty_string_if_invalid_affiliate_id() {
-		$this->assertSame( '', affwp_get_affiliate_rate() );
+	public function test_get_affiliate_rate_with_invalid_affiliate_id_should_default_to_default_rate() {
+		$default_rate = affiliate_wp()->settings->get( 'referral_rate', 20 );
+
+		$this->assertSame( $default_rate, affwp_get_affiliate_rate() );
 	}
 
 	/**
 	 * @covers ::affwp_get_affiliate_rate()
 	 */
-	public function test_get_affiliate_rate_should_return_empty_string_if_invalid_affiliate_object() {
-		$this->assertSame( '', affwp_get_affiliate_rate( new \stdClass() ) );
+	public function test_get_affiliate_rate_with_invalid_affiliate_object_should_default_to_default_rate() {
+		$default_rate = affiliate_wp()->settings->get( 'referral_rate', 20 );
+
+		$this->assertSame( $default_rate, affwp_get_affiliate_rate( new \stdClass() ) );
+	}
+
+	/**
+	 * @covers ::affwp_get_affiliate_rate()
+	 */
+	public function test_get_affiliate_rate_with_invalid_affiliate_id_formatted_true_should_return_formatted_default_rate() {
+		$default_rate = affiliate_wp()->settings->get( 'referral_rate', 20 );
+		$default_type = affiliate_wp()->settings->get( 'referral_rate_type', 'percentage' );
+
+		if ( 'percentage' === affiliate_wp()->settings->get( 'referral_rate_type', 'percentage' ) ) {
+			$default_rate = $default_rate / 100;
+		}
+
+		$this->assertSame( affwp_format_rate( $default_rate ), affwp_get_affiliate_rate( 0, true ) );
+	}
+
+	/**
+	 * @covers ::affwp_get_affiliate_rate()
+	 */
+	public function test_get_affiliate_rate_with_invalid_affiliate_object_formatted_true_should_return_formatted_default_rate() {
+		$default_rate = affiliate_wp()->settings->get( 'referral_rate', 20 );
+
+		if ( 'percentage' === affiliate_wp()->settings->get( 'referral_rate_type', 'percentage' ) ) {
+			$default_rate = $default_rate / 100;
+		}
+
+		$this->assertSame( affwp_format_rate( $default_rate ), affwp_get_affiliate_rate( new \stdClass(), true ) );
 	}
 
 	/**

--- a/tests/affiliates/test-affiliate-functions.php
+++ b/tests/affiliates/test-affiliate-functions.php
@@ -378,8 +378,13 @@ class Tests extends UnitTestCase {
 	 */
 	public function test_get_affiliate_rate_with_invalid_affiliate_id_should_default_to_default_rate() {
 		$default_rate = affiliate_wp()->settings->get( 'referral_rate', 20 );
+		$default_type = affiliate_wp()->settings->get( 'referral_rate_type', 'percentage' );
 
-		$this->assertSame( $default_rate, affwp_get_affiliate_rate() );
+		if ( 'percentage' === affiliate_wp()->settings->get( 'referral_rate_type', 'percentage' ) ) {
+			$default_rate = $default_rate / 100;
+		}
+
+		$this->assertEquals( $default_rate, affwp_get_affiliate_rate() );
 	}
 
 	/**
@@ -387,8 +392,13 @@ class Tests extends UnitTestCase {
 	 */
 	public function test_get_affiliate_rate_with_invalid_affiliate_object_should_default_to_default_rate() {
 		$default_rate = affiliate_wp()->settings->get( 'referral_rate', 20 );
+		$default_type = affiliate_wp()->settings->get( 'referral_rate_type', 'percentage' );
 
-		$this->assertSame( $default_rate, affwp_get_affiliate_rate( new \stdClass() ) );
+		if ( 'percentage' === affiliate_wp()->settings->get( 'referral_rate_type', 'percentage' ) ) {
+			$default_rate = $default_rate / 100;
+		}
+
+		$this->assertEquals( $default_rate, affwp_get_affiliate_rate( new \stdClass() ) );
 	}
 
 	/**


### PR DESCRIPTION
Issue: #1656