### PR TITLE
issue/1674 – Avoid using $this in a closure when registering Reports tabs

### DIFF
--- a/includes/abstracts/class-affwp-reports-tab.php
+++ b/includes/abstracts/class-affwp-reports-tab.php
@@ -82,8 +82,9 @@ abstract class Tab {
 	 */
 	public function __construct() {
 		// Deliberately hooked with an anonymous function. Use the 'affwp_reports_tabs' hook to remove tabs.
-		add_filter( 'affwp_reports_tabs', function( $tabs ) {
-			$tabs[ $this->tab_id ] = $this->label;
+		$inst = $this;
+		add_filter( 'affwp_reports_tabs', function( $tabs ) use ( $inst ) {
+			$tabs[ $inst->tab_id ] = $inst->label;
 			return $tabs;
 		} );
 


### PR DESCRIPTION
Issue: #1674 