### PR TITLE
issue/1676 – Bail early from the PayPal script if the form action is empty.

### DIFF
--- a/includes/integrations/class-paypal.php
+++ b/includes/integrations/class-paypal.php
@@ -36,7 +36,7 @@ class Affiliate_WP_PayPal extends Affiliate_WP_Base {
 
 				var action = $(this).prop( 'action' );
 
-				if( ! action.indexOf( 'paypal.com/cgi-bin/webscr' ) ) {
+				if( '' == action || ! action.indexOf( 'paypal.com/cgi-bin/webscr' ) ) {
 					return;
 				}
 


### PR DESCRIPTION
Issue: #1676 