### PR TITLE
Issue/1695 – Revert affwp_get_affiliate_rate() to (mostly) pre-1.9 code.

### DIFF
--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -310,36 +310,32 @@ function affwp_get_affiliate_status_label( $affiliate = 0 ) {
  * @return string Affiliate rate, empty string otherwise.
  */
 function affwp_get_affiliate_rate( $affiliate = 0, $formatted = false, $product_rate = '', $reference = '' ) {
+	// Forward-compat with affiliate objects.
+	$affiliate_id = ( $affiliate instanceof AffWP\Affiliate ) ? $affiliate->ID : $affiliate;
 
 	// Global referral rate setting, fallback to 20
 	$default_rate = affiliate_wp()->settings->get( 'referral_rate', 20 );
 	$default_rate = affwp_abs_number_round( $default_rate );
 
-	// Back-compat for optional $affiliate.
-	if ( ! $affiliate = affwp_get_affiliate( $affiliate ) ) {
-		$affiliate_id   = 0;
-		$affiliate_rate = null;
-	} else {
-		$affiliate_id   = $affiliate->ID;
-		$affiliate_rate = $affiliate->rate();
-	}
-
 	// Get product-specific referral rate, fallback to global rate
 	$product_rate = affwp_abs_number_round( $product_rate );
 	$product_rate = ( null !== $product_rate ) ? $product_rate : $default_rate;
+
+	// Get affiliate-specific referral rate
+	$affiliate_rate = affiliate_wp()->affiliates->get_column( 'rate', $affiliate_id );
 
 	// Get rate in order of priority: Affiliate -> Product -> Global
 	$rate = affwp_abs_number_round( $affiliate_rate );
 	$rate = ( null !== $rate ) ? $rate : $product_rate;
 
-	// Get the referral rate type.
+	// Get the referral rate type
 	$type = affwp_get_affiliate_rate_type( $affiliate_id );
 
 	// Format percentage rates
 	$rate = ( 'percentage' === $type ) ? $rate / 100 : $rate;
 
 	/**
-	 * Filters the affiliate rate.
+	 * Filter the affiliate rate
 	 *
 	 * @param  string  $rate
 	 * @param  int     $affiliate_id
@@ -356,7 +352,6 @@ function affwp_get_affiliate_rate( $affiliate = 0, $formatted = false, $product_
 	$rate = affwp_format_rate( $rate, $type );
 
 	return $rate;
-
 }
 
 /**

--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -311,7 +311,15 @@ function affwp_get_affiliate_status_label( $affiliate = 0 ) {
  */
 function affwp_get_affiliate_rate( $affiliate = 0, $formatted = false, $product_rate = '', $reference = '' ) {
 	// Forward-compat with affiliate objects.
-	$affiliate_id = ( $affiliate instanceof AffWP\Affiliate ) ? $affiliate->ID : $affiliate;
+	if ( is_object( $affiliate ) ) {
+		if ( isset( $affiliate->affiliate_id ) ) {
+			$affiliate_id = $affiliate->affiliate_id;
+		} else {
+			$affiliate_id = 0;
+		}
+	} else {
+		$affiliate_id = $affiliate;
+	}
 
 	// Global referral rate setting, fallback to 20
 	$default_rate = affiliate_wp()->settings->get( 'referral_rate', 20 );

--- a/includes/class-affwp-affiliate.php
+++ b/includes/class-affwp-affiliate.php
@@ -239,11 +239,7 @@ final class Affiliate extends Base_Object {
 	 * @return int Rate. If empty, defaults to the global referral rate.
 	 */
 	public function rate() {
-		if ( empty( $this->rate ) ) {
-			return affiliate_wp()->settings->get( 'referral_rate', 20 );
-		}
-
-		return $this->rate;
+		return affwp_get_affiliate_rate( $this->ID );
 	}
 
 	/**


### PR DESCRIPTION
Issue: #1695