### PR TITLE
issue/1697 – Explicity bail from the PayPal form handler if action is undefined no match

### DIFF
--- a/includes/integrations/class-paypal.php
+++ b/includes/integrations/class-paypal.php
@@ -36,7 +36,7 @@ class Affiliate_WP_PayPal extends Affiliate_WP_Base {
 
 				var action = $(this).prop( 'action' );
 
-				if( '' == action || ! action.indexOf( 'paypal.com/cgi-bin/webscr' ) ) {
+				if( 'undefined' == action || -1 == action.indexOf( 'paypal.com/cgi-bin/webscr' ) ) {
 					return;
 				}
 


### PR DESCRIPTION
Issue: #1697