### PR TITLE
issue/1714 – Invalidate campaign caches when the item cache is cleaned

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -660,7 +660,7 @@ function affwp_clean_item_cache( $object ) {
 	// Invalidate core object queries.
 	wp_cache_set( 'last_changed', $last_changed, $db_cache_group );
 
-	// Explicitly invalid the campaigns cache.
+	// Explicitly invalidate the campaigns cache.
 	wp_cache_set( 'last_changed', $last_changed, affiliate_wp()->campaigns->cache_group );
 }
 

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -655,8 +655,13 @@ function affwp_clean_item_cache( $object ) {
 	$db_groups      = $Object_Class::get_db_groups();
 	$db_cache_group = isset( $db_groups->secondary ) ? $db_groups->secondary : $db_groups->primary;
 
-	// last_changed for queries.
-	wp_cache_set( 'last_changed', microtime(), $db_cache_group );
+	$last_changed = microtime();
+
+	// Invalidate core object queries.
+	wp_cache_set( 'last_changed', $last_changed, $db_cache_group );
+
+	// Explicitly invalid the campaigns cache.
+	wp_cache_set( 'last_changed', $last_changed, affiliate_wp()->campaigns->cache_group );
 }
 
 /**


### PR DESCRIPTION
Issue: #1714