### PR TITLE
issue/1815 - Define $user_id as 0 to avoid a notice on the Exchange/MemberPress coupon edit screens.

### DIFF
--- a/includes/integrations/class-exchange.php
+++ b/includes/integrations/class-exchange.php
@@ -288,7 +288,8 @@ class Affiliate_WP_Exchange extends Affiliate_WP_Base {
 
 		add_filter( 'affwp_is_admin_page', '__return_true' );
 		affwp_admin_scripts();
-
+		
+		$user_id      = 0;
 		$user_name    = '';
 		$coupon_id    = ! empty( $_REQUEST['post'] ) ? absint( $_REQUEST['post'] ) : 0;
 		$affiliate_id = get_post_meta( $coupon_id, 'affwp_coupon_affiliate', true );

--- a/includes/integrations/class-memberpress.php
+++ b/includes/integrations/class-memberpress.php
@@ -272,6 +272,7 @@ class Affiliate_WP_MemberPress extends Affiliate_WP_Base {
 		add_filter( 'affwp_is_admin_page', '__return_true' );
 		affwp_admin_scripts();
 
+		$user_id      = 0;
 		$user_name    = '';
 		$affiliate_id = get_post_meta( $post->ID, 'affwp_discount_affiliate', true );
 		if( $affiliate_id ) {


### PR DESCRIPTION
#1815