### PR TITLE
Fix a bug where the tld was removed from paged urls when tld==referral_var

### DIFF
--- a/includes/class-tracking.php
+++ b/includes/class-tracking.php
@@ -766,10 +766,10 @@ class Affiliate_WP_Tracking {
 			$link = remove_query_arg( $referral_var, $link );
 
 			// Remove a pretty referral ID or username.
-			preg_match( "/$referral_var\/(\w+)\//", $link, $pretty_matches );
+			preg_match( "/\/$referral_var\/(\w+)\//", $link, $pretty_matches );
 
 			if ( ! empty( $pretty_matches[0] ) ) {
-				$link = str_replace( $pretty_matches[0], '', $link );
+				$link = str_replace( $pretty_matches[0], '/', $link );
 			}
 		}
 


### PR DESCRIPTION
Add a leading / to the pattern before the referral var so it can't match the domain part of the url.

**Why?**
Before, if we had a site at `example.com` and set the referral_var to `com`, then our paged urls would look something like `example.page/2`