### PR TITLE
issue/1870 – Don't attempt to access a nonexistent $affiliate object in the list() callback

### DIFF
--- a/includes/cli/class-creative-sub-commands.php
+++ b/includes/cli/class-creative-sub-commands.php
@@ -320,7 +320,7 @@ class Sub_Commands extends Base {
 				$creatives = wp_list_pluck( $creatives, 'creative_id' );
 			} else {
 				$creatives = array_map( function( $creative ) {
-					$creative->ID = $affiliate->creative_id;
+					$creative->ID = $creative->creative_id;
 
 					return $creative;
 				}, $creatives );


### PR DESCRIPTION
Issue: #1870