### PR TITLE
Issues/1878 - Block referral if affiliate’s email is used

### DIFF
--- a/includes/integrations/class-gravityforms.php
+++ b/includes/integrations/class-gravityforms.php
@@ -268,11 +268,7 @@ class Affiliate_WP_Gravity_Forms extends Affiliate_WP_Base {
 			}
 		}
 
-		if ( $emails ) {
-			return $emails;
-		}
-
-		return false;
+		return $emails;
 
 	}
 

--- a/includes/integrations/class-gravityforms.php
+++ b/includes/integrations/class-gravityforms.php
@@ -45,6 +45,10 @@ class Affiliate_WP_Gravity_Forms extends Affiliate_WP_Base {
 	 */
 	public function add_pending_referral( $entry, $form ) {
 
+		// Get affiliate ID
+		$affiliate_id = $this->affiliate_id;
+
+		// Block referral if form does not allow them
 		if ( ! rgar( $form, 'affwp_allow_referrals' ) ) {
 			return;
 		}
@@ -52,8 +56,27 @@ class Affiliate_WP_Gravity_Forms extends Affiliate_WP_Base {
 		// Check if an affiliate coupon was included
 		$this->maybe_check_coupons( $form, $entry );
 
-		if( ! $this->was_referred() && empty( $this->affiliate_id ) ) {
+		// Block referral if not referred or affiliate ID is empty
+		if ( ! $this->was_referred() && empty( $affiliate_id ) ) {
 			return;
+		}
+
+		// Get all emails from submitted form
+		$emails = $this->get_emails( $entry, $form );
+
+		// Block referral if any of the affiliate's emails have been submitted
+		if ( $emails ) {
+			foreach ( $emails as $customer_email ) {
+				if ( $this->is_affiliate_email( $customer_email, $affiliate_id ) ) {
+
+					if ( $this->debug ) {
+						$this->log( 'Referral not created because affiliate\'s own account was used.' );
+					}
+
+					return false;
+
+				}
+			}
 		}
 
 		// Do some craziness to determine the price (this should be easy but is not)
@@ -221,6 +244,35 @@ class Affiliate_WP_Gravity_Forms extends Affiliate_WP_Base {
 			}
 
 		}
+
+	}
+
+	/**
+	 * Get all emails from form
+	 *
+	 * @since 2.0
+	 * @access public
+	 * @return array $emails all emails submitted via email fields
+	 */
+	public function get_emails( $entry, $form ) {
+
+		$email_fields = GFCommon::get_email_fields( $form );
+
+		$emails = array();
+
+		if ( $email_fields ) {
+			foreach ( $email_fields as $email_field ) {
+				if ( ! empty( $entry[ $email_field->id ] ) ) {
+					$emails[] = $entry[ $email_field->id ];
+				}
+			}
+		}
+
+		if ( $emails ) {
+			return $emails;
+		}
+
+		return false;
 
 	}
 


### PR DESCRIPTION
This checks all email fields on the Gravity Form, and if any email matches the affiliate’s email, the referral is blocked.

#1878 