### PR TITLE
Issue/1916 - Allow referrals from COD orders to be completed

### DIFF
--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -272,16 +272,10 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 	 * Marks a referral as complete when payment is completed.
 	 *
 	 * @since 1.0
-	 * @since 1.8 Orders that are COD and 'wc-processing' status are now skipped from "completion".
+	 * @since 2.0 Orders that are COD and transitioning from `wc-processing` to `wc-complete` stati are now able to be completed.
 	 * @access public
 	 */
 	public function mark_referral_complete( $order_id = 0 ) {
-		// If the WC status is 'wc-processing' and a COD order, leave as 'pending'.
-		if ( current_action( 'woocommerce_order_status_processing' )
-		     && 'cod' === get_post_meta( $order_id, '_payment_method', true )
-		) {
-			return;
-		}
 
 		$this->complete_referral( $order_id );
 	}

--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -277,6 +277,13 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 	 */
 	public function mark_referral_complete( $order_id = 0 ) {
 
+		$this->order = apply_filters( 'affwp_get_woocommerce_order', new WC_Order( $order_id ) );
+
+		// If the WC status is 'wc-processing' and a COD order, leave as 'pending'.
+		if ( 'wc-processing' == $order->post_status && 'cod' === get_post_meta( $order_id, '_payment_method', true ) ) {
+			return;
+		}
+
 		$this->complete_referral( $order_id );
 	}
 

--- a/includes/integrations/class-woocommerce.php
+++ b/includes/integrations/class-woocommerce.php
@@ -280,7 +280,7 @@ class Affiliate_WP_WooCommerce extends Affiliate_WP_Base {
 		$this->order = apply_filters( 'affwp_get_woocommerce_order', new WC_Order( $order_id ) );
 
 		// If the WC status is 'wc-processing' and a COD order, leave as 'pending'.
-		if ( 'wc-processing' == $order->post_status && 'cod' === get_post_meta( $order_id, '_payment_method', true ) ) {
+		if ( 'wc-processing' == $this->order->post_status && 'cod' === get_post_meta( $order_id, '_payment_method', true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
- Removes guard clause defined in 1.8, which had the effect of not allowing referral completions in cases where the pot status transitions from processing to completed.

Fixes #1916