### PR TITLE
Issue/1981: Add methods to check single integrations

### DIFF
--- a/includes/class-integrations.php
+++ b/includes/class-integrations.php
@@ -8,8 +8,22 @@ class Affiliate_WP_Integrations {
 
 	}
 
+	/**
+	 * Gets all available AffiliateWP integrations
+	 *
+	 * @since  1.0
+	 *
+	 * @return array $integrations  Available AffiliateWP integrations.
+	 */
 	public function get_integrations() {
 
+		/**
+		 * An array of all available AffiliateWP integrations.
+		 * Append to and return the array to define a new integration.
+		 *
+		 * @param array  $integrations  Available AffiliateWP integrations.
+		 * @since 1.0
+		 */
 		return apply_filters( 'affwp_integrations', array(
 			'contactform7'   => 'Contact Form 7',
 			'edd'            => 'Easy Digital Downloads',
@@ -43,8 +57,54 @@ class Affiliate_WP_Integrations {
 
 	}
 
+	/**
+	 * Gets the currently-enabled AffiliateWP integrations.
+	 *
+	 * @return array The currently-enabled AffiliateWP integrations.
+	 * @since  1.0
+	 */
 	public function get_enabled_integrations() {
 		return affiliate_wp()->settings->get( 'integrations', array() );
+	}
+
+	/**
+	 * Check if the specified integration is a valid AffiliateWP integration.
+	 *
+	 * @param  string  $integration  The integration to check.
+	 * @return boolean               True if a valid integration, otherwise false.
+	 * @since  2.1
+	 */
+	public function integration_is_valid( $integration ) {
+		$all_integrations = $this->get_integrations();
+
+		if ( array_key_exists( $integration, $all_integrations ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if the specified AffiliateWP integration is enabled.
+	 *
+	 *
+	 * @param  string  $integration  The integration to check.
+	 * @return boolean               True if enabled, otherwise false.
+	 * @since  2.1
+	 */
+	public function integration_is_enabled( $integration ) {
+
+		if ( ! $this->integration_is_valid( $integration ) ) {
+			return false;
+		}
+
+		$enabled_integrations = $this->get_enabled_integrations();
+
+		if ( array_key_exists( $integration, $enabled_integrations ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	public function load() {


### PR DESCRIPTION
- Defines `Affiliate_WP_Integrations::integration_is_enabled()`
- Defines `Affiliate_WP_Integrations::integration_is_valid()`
- Related inline docs for `Affiliate_WP_Integrations` properties.
- Implements #1981