### PR TITLE
Issue/2120 Allow plugins to extend the login form with password alternatives

### DIFF
--- a/includes/class-login.php
+++ b/includes/class-login.php
@@ -69,16 +69,20 @@ class Affiliate_WP_Login {
 			$this->add_error( 'no_such_user', __( 'No such user', 'affiliate-wp' ) );
 		}
 
-		if ( empty( $_POST['affwp_user_pass'] ) ) {
-			$this->add_error( 'empty_password', __( 'Please enter a password', 'affiliate-wp' ) );
-		}
-
-		if ( $user ) {
-			// check the user's login with their password
-			if ( ! wp_check_password( $_POST['affwp_user_pass'], $user->user_pass, $user->ID ) ) {
-				// if the password is incorrect for the specified user
-				$this->add_error( 'password_incorrect', __( 'Incorrect username or password', 'affiliate-wp' ) );
+		if ( apply_filters( 'affwp_login_check_password', true, $user ) ) {
+			
+			if ( empty( $_POST['affwp_user_pass'] ) ) {
+				$this->add_error( 'empty_password', __( 'Please enter a password', 'affiliate-wp' ) );
 			}
+
+			if ( $user ) {
+				// check the user's login with their password
+				if ( ! wp_check_password( $_POST['affwp_user_pass'], $user->user_pass, $user->ID ) ) {
+					// if the password is incorrect for the specified user
+					$this->add_error( 'password_incorrect', __( 'Incorrect username or password', 'affiliate-wp' ) );
+				}
+			}
+			
 		}
 
 		if ( function_exists( 'is_limit_login_ok' ) && ! is_limit_login_ok() ) {

--- a/includes/class-login.php
+++ b/includes/class-login.php
@@ -69,6 +69,14 @@ class Affiliate_WP_Login {
 			$this->add_error( 'no_such_user', __( 'No such user', 'affiliate-wp' ) );
 		}
 
+		/**
+		 * Allow extensions to authenticate via a different mechanism
+		 *
+		 * @since 2.0.6
+		 *
+		 * @param boolean Whether to check the password or not
+		 * @param WP_User $user The WordPress user whose password is being checked.
+		 */
 		if ( apply_filters( 'affwp_login_check_password', true, $user ) ) {
 			
 			if ( empty( $_POST['affwp_user_pass'] ) ) {


### PR DESCRIPTION
The previous code provides no easy/elegant way for an extension to extend the login form. In my use case, I am developing a plugin which will allow the user to scan a visible code with their smartphone, as a non-compulsory alternative to a password.

This patch provides a filter which allows an extension to instruction Affiliate-WP that it does not need to verify the password (which would be used in the case that the extension has performed its own verification).

Issue: #2120