### PR TITLE
issue/2078 – Skip registering the referral var as a query var in WP 4.3+.

### DIFF
--- a/includes/class-rewrites.php
+++ b/includes/class-rewrites.php
@@ -24,16 +24,6 @@ class Affiliate_WP_Rewrites {
 
 		add_action( 'init', array( $this, 'rewrites' ), 999999 );
 
-		if ( function_exists( 'wc_get_page_id' ) && get_option( 'page_on_front' ) == wc_get_page_id( 'shop' ) ) {
-
-			add_action( 'pre_get_posts', array( $this, 'unset_query_arg' ), -1 );
-
-		} else {
-
-			add_action( 'pre_get_posts', array( $this, 'unset_query_arg' ), 999999 );
-
-		}
-
 		add_action( 'redirect_canonical', array( $this, 'prevent_canonical_redirect' ), 0, 2 );
 	}
 
@@ -92,7 +82,7 @@ class Affiliate_WP_Rewrites {
 
 		}
 
-		add_rewrite_endpoint( affiliate_wp()->tracking->get_referral_var(), EP_ALL );
+		add_rewrite_endpoint( affiliate_wp()->tracking->get_referral_var(), EP_ALL, false );
 
 	}
 


### PR DESCRIPTION
<!--- Please prefix your PR description above with the issue number: issue/### – PR Description -->

Issue: #2078