### PR TITLE
#2261 Compatibility fix with WP Simple Pay version 3.0.0

### DIFF
--- a/includes/integrations/class-stripe.php
+++ b/includes/integrations/class-stripe.php
@@ -80,7 +80,18 @@ class Affiliate_WP_Stripe extends Affiliate_WP_Base {
 			if( is_object( $object->customer ) && ! empty( $object->customer->email ) ) {
 				$email = $object->customer->email;
 			} else {
-				$email = sanitize_text_field( $_POST['stripeEmail'] );
+
+				if ( isset( $_POST['stripeEmail'] ) ) {
+
+					// WP Simple Pay < 3.0
+					$email = sanitize_text_field( $_POST['stripeEmail'] );
+				} elseif ( isset( $_POST['simpay_stripe_email'] ) ) {
+
+					// WP Simple Pay >= 3.0
+					$email = sanitize_text_field( $_POST['simpay_stripe_email'] );
+				} else {
+					// Something else went wrong...
+				}
 			}
 
 			if( $this->is_affiliate_email( $email, $this->affiliate_id ) ) {

--- a/includes/integrations/class-stripe.php
+++ b/includes/integrations/class-stripe.php
@@ -64,7 +64,7 @@ class Affiliate_WP_Stripe extends Affiliate_WP_Base {
 
 					$stripe_amount = $object->amount;
 					$currency      = $object->currency;
-					$description   = $object->description;
+					$description   = ! empty( $object->description ) ? $object->description : '';
 					$mode          = $object->livemode;
 
 					break;

--- a/includes/integrations/class-stripe.php
+++ b/includes/integrations/class-stripe.php
@@ -80,7 +80,6 @@ class Affiliate_WP_Stripe extends Affiliate_WP_Base {
 			if( is_object( $object->customer ) && ! empty( $object->customer->email ) ) {
 				$email = $object->customer->email;
 			} else {
-
 				if ( isset( $_POST['stripeEmail'] ) ) {
 
 					// WP Simple Pay < 3.0
@@ -89,8 +88,6 @@ class Affiliate_WP_Stripe extends Affiliate_WP_Base {
 
 					// WP Simple Pay >= 3.0
 					$email = sanitize_text_field( $_POST['simpay_stripe_email'] );
-				} else {
-					// Something else went wrong...
 				}
 			}
 


### PR DESCRIPTION
<!--- Please prefix your PR description above with the issue number: issue/### – PR Description -->

Issue: #2261

Part of this fix is the empty description fix in the issue above. There is another part (no GH issue). The second part fixes the check for the Stripe email adress that gets posted. This is changed in WP Simple Pay 3.0.0 and I have added a check for that new value as well as keeping the old value in place for backwards compatibility.