### PR TITLE
Use affiliate ID property instead of local variable. Fixes #2278

### DIFF
--- a/includes/REST/class-rest-authentication.php
+++ b/includes/REST/class-rest-authentication.php
@@ -30,6 +30,9 @@ final class Authentication {
 	 * @return int API consumer user ID if authenticated.
 	 */
 	public function authenticate( $user_id ) {
+
+		//print_r( $_SERVER ); exit;
+
 		if ( ! empty( $user_id ) || empty( $_SERVER['PHP_AUTH_USER'] ) ) {
 			return $user_id;
 		}

--- a/includes/REST/class-rest-authentication.php
+++ b/includes/REST/class-rest-authentication.php
@@ -31,8 +31,6 @@ final class Authentication {
 	 */
 	public function authenticate( $user_id ) {
 
-		//print_r( $_SERVER ); exit;
-
 		if ( ! empty( $user_id ) || empty( $_SERVER['PHP_AUTH_USER'] ) ) {
 			return $user_id;
 		}

--- a/includes/integrations/class-gravityforms.php
+++ b/includes/integrations/class-gravityforms.php
@@ -45,9 +45,6 @@ class Affiliate_WP_Gravity_Forms extends Affiliate_WP_Base {
 	 */
 	public function add_pending_referral( $entry, $form ) {
 
-		// Get affiliate ID
-		$affiliate_id = $this->affiliate_id;
-
 		// Block referral if form does not allow them
 		if ( ! rgar( $form, 'affwp_allow_referrals' ) ) {
 			return;
@@ -57,7 +54,7 @@ class Affiliate_WP_Gravity_Forms extends Affiliate_WP_Base {
 		$this->maybe_check_coupons( $form, $entry );
 
 		// Block referral if not referred or affiliate ID is empty
-		if ( ! $this->was_referred() && empty( $affiliate_id ) ) {
+		if ( ! $this->was_referred() && empty( $this->affiliate_id ) ) {
 			return;
 		}
 
@@ -67,7 +64,7 @@ class Affiliate_WP_Gravity_Forms extends Affiliate_WP_Base {
 		// Block referral if any of the affiliate's emails have been submitted
 		if ( $emails ) {
 			foreach ( $emails as $customer_email ) {
-				if ( $this->is_affiliate_email( $customer_email, $affiliate_id ) ) {
+				if ( $this->is_affiliate_email( $customer_email, $this->affiliate_id ) ) {
 
 					$this->log( 'Referral not created because affiliate\'s own account was used.' );
 


### PR DESCRIPTION
The affiliate ID was set up in a local variable before checking if an affiliate coupon was used so the found affiliate ID was never set to the local variable.

Issue: #2278