### PR TITLE
Add affiliate object to the 'affwp_affiliate_deleted' hook

### DIFF
--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -581,8 +581,7 @@ function affwp_delete_affiliate( $affiliate, $delete_data = false ) {
 
 		delete_user_meta( $affiliate->user_id, 'affwp_referral_notifications' );
 		delete_user_meta( $affiliate->user_id, 'affwp_promotion_method' );
-		
-		do_action( 'affwp_affiliate_delete_data', $affiliate );
+
 	}
 
 	$deleted = affiliate_wp()->affiliates->delete( $affiliate_id, 'affiliate' );
@@ -594,8 +593,9 @@ function affwp_delete_affiliate( $affiliate, $delete_data = false ) {
 		 *
 		 * @param int  $affiliate_id The affiliate ID.
 		 * @param bool $delete_data  Whether the user data was also flagged for deletion.
+		 * @param AffWP\Affiliate
 		 */
-		do_action( 'affwp_affiliate_deleted', $affiliate_id, $delete_data );
+		do_action( 'affwp_affiliate_deleted', $affiliate_id, $delete_data, $affiliate );
 
 	}
 

--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -593,7 +593,7 @@ function affwp_delete_affiliate( $affiliate, $delete_data = false ) {
 		 *
 		 * @param int  $affiliate_id The affiliate ID.
 		 * @param bool $delete_data  Whether the user data was also flagged for deletion.
-		 * @param AffWP\Affiliate $affiliate Affiliate object
+		 * @param AffWP\Affiliate $affiliate Affiliate object.
 		 */
 		do_action( 'affwp_affiliate_deleted', $affiliate_id, $delete_data, $affiliate );
 

--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -581,6 +581,8 @@ function affwp_delete_affiliate( $affiliate, $delete_data = false ) {
 
 		delete_user_meta( $affiliate->user_id, 'affwp_referral_notifications' );
 		delete_user_meta( $affiliate->user_id, 'affwp_promotion_method' );
+		
+		do_action( 'affwp_affiliate_delete_data', $affiliate );
 	}
 
 	$deleted = affiliate_wp()->affiliates->delete( $affiliate_id, 'affiliate' );

--- a/includes/affiliate-functions.php
+++ b/includes/affiliate-functions.php
@@ -593,7 +593,7 @@ function affwp_delete_affiliate( $affiliate, $delete_data = false ) {
 		 *
 		 * @param int  $affiliate_id The affiliate ID.
 		 * @param bool $delete_data  Whether the user data was also flagged for deletion.
-		 * @param AffWP\Affiliate
+		 * @param AffWP\Affiliate $affiliate Affiliate object
 		 */
 		do_action( 'affwp_affiliate_deleted', $affiliate_id, $delete_data, $affiliate );
 


### PR DESCRIPTION
Add an action that gets fired after the affiliate's data is removed.

It would have been be possible to use the 'affwp_affiliate_deleted' action but only the affiliate ID is passed which means I can't access the user ID (affiliate deleted).

<!--- Please prefix your PR description above with the issue number: issue/### – PR Description -->

Issue: #