### PR TITLE
Issue/1923: Options to disable each email

### DIFF
--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -632,6 +632,16 @@ class Affiliate_WP_Settings {
 						'desc' => __( 'Disable email notifications sent to affiliates when their affiliate application is accepted.', 'affiliate-wp' ),
 						'type' => 'checkbox'
 					),
+					'disable_application_pending_emails' => array(
+						'name' => __( 'Disable Application Pending Emails', 'affiliate-wp' ),
+						'desc' => __( 'Disable email notifications sent to affiliates when their affiliate application is pending.', 'affiliate-wp' ),
+						'type' => 'checkbox'
+					),
+					'disable_application_rejected_emails' => array(
+						'name' => __( 'Disable Application Rejected Emails', 'affiliate-wp' ),
+						'desc' => __( 'Disable email notifications sent to affiliates when their affiliate application is rejected.', 'affiliate-wp' ),
+						'type' => 'checkbox'
+					),
 					'disable_new_referral_emails' => array(
 						'name' => __( 'Disable New Referral Emails', 'affiliate-wp' ),
 						'desc' => __( 'Disable email notifications sent to affiliates when they receive a new referral.', 'affiliate-wp' ),

--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -627,6 +627,21 @@ class Affiliate_WP_Settings {
 						'desc' => __( 'Disable all email notifications.', 'affiliate-wp' ),
 						'type' => 'checkbox'
 					),
+					'disable_application_accepted_emails' => array(
+						'name' => __( 'Disable Application Accepted Emails', 'affiliate-wp' ),
+						'desc' => __( 'Disable email notifications sent to affiliates when their affiliate application is accepted.', 'affiliate-wp' ),
+						'type' => 'checkbox'
+					),
+					'disable_new_referral_emails' => array(
+						'name' => __( 'Disable New Referral Emails', 'affiliate-wp' ),
+						'desc' => __( 'Disable email notifications sent to affiliates when they receive a new referral.', 'affiliate-wp' ),
+						'type' => 'checkbox'
+					),
+					'registration_notifications' => array(
+						'name' => __( 'Notify Admin', 'affiliate-wp' ),
+						'desc' => __( 'Notify site admin of new affiliate registrations.', 'affiliate-wp' ),
+						'type' => 'checkbox'
+					),
 					'email_logo' => array(
 						'name' => __( 'Logo', 'affiliate-wp' ),
 						'desc' => __( 'Upload or choose a logo to be displayed at the top of emails.', 'affiliate-wp' ),
@@ -649,11 +664,6 @@ class Affiliate_WP_Settings {
 						'desc' => __( 'The email address to send emails from. This will act as the "from" and "reply-to" address.', 'affiliate-wp' ),
 						'type' => 'text',
 						'std' => get_bloginfo( 'admin_email' )
-					),
-					'registration_notifications' => array(
-						'name' => __( 'Notify Admin', 'affiliate-wp' ),
-						'desc' => __( 'Notify site admin of new affiliate registrations.', 'affiliate-wp' ),
-						'type' => 'checkbox'
 					),
 					'registration_subject' => array(
 						'name' => __( 'Registration Email Subject', 'affiliate-wp' ),

--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -154,6 +154,10 @@ add_action( 'affwp_set_affiliate_status', 'affwp_notify_on_approval', 10, 3 );
  */
 function affwp_notify_on_pending_affiliate_registration( $affiliate_id = 0, $status = '', $args ) {
 
+	if( ! affiliate_wp()->settings->get( 'disable_application_pending_emails' ) ) {
+		return;
+	}
+
 	if ( empty( $affiliate_id ) ) {
 		return;
 	}
@@ -192,6 +196,10 @@ add_action( 'affwp_auto_register_user', 'affwp_notify_on_pending_affiliate_regis
  * @param string $old_status
  */
 function affwp_notify_on_rejected_affiliate_registration( $affiliate_id = 0, $status = '', $old_status = '' ) {
+
+	if( ! affiliate_wp()->settings->get( 'disable_application_rejected_emails' ) ) {
+		return;
+	}
 
 	if ( empty( $affiliate_id ) ) {
 		return;
@@ -232,7 +240,7 @@ function affwp_notify_on_new_referral( $affiliate_id = 0, $referral ) {
 	if( ! affiliate_wp()->settings->get( 'disable_new_referral_emails' ) ) {
 		return;
 	}
-	
+
 	$user_id = affwp_get_affiliate_user_id( $affiliate_id );
 
 	if( ! get_user_meta( $user_id, 'affwp_referral_notifications', true ) ) {

--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -22,7 +22,7 @@ if( ! defined( 'ABSPATH' ) ) exit;
  */
 function affwp_notify_on_registration( $affiliate_id = 0, $status = '', $args = array() ) {
 
-	if( ! affiliate_wp()->settings->get( 'registration_notifications' ) ) {
+	if( affiliate_wp()->settings->get( 'registration_notifications' ) ) {
 		return;
 	}
 
@@ -82,7 +82,7 @@ add_action( 'affwp_auto_register_user', 'affwp_notify_on_registration', 10, 3 );
  */
 function affwp_notify_on_approval( $affiliate_id = 0, $status = '', $old_status = '' ) {
 
-	if( ! affiliate_wp()->settings->get( 'disable_application_accepted_emails' ) ) {
+	if( affiliate_wp()->settings->get( 'disable_application_accepted_emails' ) ) {
 		return;
 	}
 
@@ -154,7 +154,7 @@ add_action( 'affwp_set_affiliate_status', 'affwp_notify_on_approval', 10, 3 );
  */
 function affwp_notify_on_pending_affiliate_registration( $affiliate_id = 0, $status = '', $args ) {
 
-	if( ! affiliate_wp()->settings->get( 'disable_application_pending_emails' ) ) {
+	if( affiliate_wp()->settings->get( 'disable_application_pending_emails' ) ) {
 		return;
 	}
 
@@ -197,7 +197,7 @@ add_action( 'affwp_auto_register_user', 'affwp_notify_on_pending_affiliate_regis
  */
 function affwp_notify_on_rejected_affiliate_registration( $affiliate_id = 0, $status = '', $old_status = '' ) {
 
-	if( ! affiliate_wp()->settings->get( 'disable_application_rejected_emails' ) ) {
+	if( affiliate_wp()->settings->get( 'disable_application_rejected_emails' ) ) {
 		return;
 	}
 
@@ -237,7 +237,7 @@ add_action( 'affwp_set_affiliate_status', 'affwp_notify_on_rejected_affiliate_re
  */
 function affwp_notify_on_new_referral( $affiliate_id = 0, $referral ) {
 
-	if( ! affiliate_wp()->settings->get( 'disable_new_referral_emails' ) ) {
+	if( affiliate_wp()->settings->get( 'disable_new_referral_emails' ) ) {
 		return;
 	}
 

--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -22,7 +22,7 @@ if( ! defined( 'ABSPATH' ) ) exit;
  */
 function affwp_notify_on_registration( $affiliate_id = 0, $status = '', $args = array() ) {
 
-	if( affiliate_wp()->settings->get( 'registration_notifications' ) ) {
+	if( ! affiliate_wp()->settings->get( 'registration_notifications' ) ) {
 		return;
 	}
 

--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -82,6 +82,10 @@ add_action( 'affwp_auto_register_user', 'affwp_notify_on_registration', 10, 3 );
  */
 function affwp_notify_on_approval( $affiliate_id = 0, $status = '', $old_status = '' ) {
 
+	if( ! affiliate_wp()->settings->get( 'disable_application_accepted_emails' ) ) {
+		return;
+	}
+
 	if( empty( $affiliate_id ) || 'active' !== $status ) {
 		return;
 	}
@@ -225,6 +229,10 @@ add_action( 'affwp_set_affiliate_status', 'affwp_notify_on_rejected_affiliate_re
  */
 function affwp_notify_on_new_referral( $affiliate_id = 0, $referral ) {
 
+	if( ! affiliate_wp()->settings->get( 'disable_new_referral_emails' ) ) {
+		return;
+	}
+	
 	$user_id = affwp_get_affiliate_user_id( $affiliate_id );
 
 	if( ! get_user_meta( $user_id, 'affwp_referral_notifications', true ) ) {


### PR DESCRIPTION
- Adds options to disable additional affiliates emails via `disable_application_accepted_emails`, `disable_new_referral_emails`.

- Moves `registration_notifications` setting to be underneath other disable email options.

- Adds checks for new disabled emails settings in email functions `affwp_notify_on_new_referral` and `affwp_notify_on_approval`.

- #1923