### PR TITLE
issue/1960 - Add global referral notifications option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
 
 env:
     - WP_VERSION=latest WP_MULTISITE=0
@@ -18,8 +19,6 @@ env:
 matrix:
   include:
     - php: 7.1
-      env: WP_TRAVISCI=travis:js
-    - php: 7.0
       env: WP_VERSION=trunk
     - php: 5.3
       dist: precise

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 AffiliateWP
 [![Build Status](https://travis-ci.org/AffiliateWP/AffiliateWP.svg?branch=master)](https://travis-ci.org/AffiliateWP/AffiliateWP)
-[![version](https://img.shields.io/badge/version-v2.1.4.1-blue.svg)](https://github.com/AffiliateWP/AffiliateWP)
+[![version](https://img.shields.io/badge/version-v2.1.4.2-blue.svg)](https://github.com/AffiliateWP/AffiliateWP)
 ============
 
 AffiliateWP is a commercial plugin available from [https://affiliatewp.com](https://affiliatewp.com). The plugin is hosted here on a public GitHub repository in order to better facilitate community contributions from developers and users alike. If you have a suggestion, a bug report, or a patch for an issue, feel free to submit it here. We do ask, however, that if you are using the plugin on a live site that you please purchase a valid license from the [website](https://affiliatewp.com). We cannot provide support to anyone that does not hold a valid license key.

--- a/affiliate-wp.php
+++ b/affiliate-wp.php
@@ -5,7 +5,7 @@
  * Description: Affiliate Plugin for WordPress
  * Author: AffiliateWP, LLC
  * Author URI: https://affiliatewp.com
- * Version: 2.1.4.1
+ * Version: 2.1.4.2
  * Text Domain: affiliate-wp
  * Domain Path: languages
  *
@@ -24,7 +24,7 @@
  * @package AffiliateWP
  * @category Core
  * @author Pippin Williamson
- * @version 2.1.4.1
+ * @version 2.1.4.2
  */
 
 // Exit if accessed directly
@@ -56,7 +56,7 @@ final class Affiliate_WP {
 	 * @since  1.0
 	 * @var    string
 	 */
-	private $version = '2.1.4.1';
+	private $version = '2.1.4.2';
 
 	/**
 	 * The affiliates DB instance variable.

--- a/includes/admin/class-notices.php
+++ b/includes/admin/class-notices.php
@@ -298,7 +298,7 @@ class Affiliate_WP_Admin_Notices {
 
 				case 'license-expired' :
 
-					$class = 'expired';
+					$class = 'error';
 					$message = sprintf(
 						__( 'Your license key expired on %s. Please <a href="%s" target="_blank">renew your license key</a>.', 'affiliate-wp' ),
 						date_i18n( get_option( 'date_format' ), strtotime( $license->expires, current_time( 'timestamp' ) ) ),

--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -679,6 +679,11 @@ class Affiliate_WP_Settings {
 						'type' => 'rich_editor',
 						'std' => __( 'Congratulations {name}!', 'affiliate-wp' ) . "\n\n" . sprintf( __( 'Your affiliate application on %s has been accepted!', 'affiliate-wp' ), home_url() ) . "\n\n" . __( 'Log into your affiliate area at', 'affiliate-wp' ) . ' {login_url}'
 					),
+					'enable_default_new_referral_emails' => array(
+						'name' => __( 'Enable New Referral Emails by Default', 'affiliate-wp' ),
+						'desc' => __( 'All affiliates will receive new referral notifications by default.', 'affiliate-wp' ),
+						'type' => 'checkbox'
+					),
 					'referral_subject' => array(
 						'name' => __( 'New Referral Email Subject', 'affiliate-wp' ),
 						'desc' => __( 'Enter the subject line for new referral emails sent when affiliates earn referrals.', 'affiliate-wp' ),

--- a/includes/admin/utilities/class-data-storage.php
+++ b/includes/admin/utilities/class-data-storage.php
@@ -30,7 +30,7 @@ class Data_Storage {
 			$value = $default;
 		}
 
-		return empty( $value ) ? false : maybe_unserialize( $value );
+		return empty( $value ) ? false : affwp_maybe_unserialize( $value );
 	}
 
 	/**

--- a/includes/class-affwp-referral.php
+++ b/includes/class-affwp-referral.php
@@ -189,6 +189,11 @@ final class Referral extends Base_Object {
 		if ( in_array( $field, array( 'referral_id', 'affiliate_id', 'visit_id', 'ID' ) ) ) {
 			$value = (int) $value;
 		}
+
+		if ( 'custom' === $field ) {
+			$value = affwp_maybe_unserialize( affwp_maybe_unserialize( $value ) );
+		}
+
 		return $value;
 	}
 

--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -225,9 +225,11 @@ add_action( 'affwp_set_affiliate_status', 'affwp_notify_on_rejected_affiliate_re
  */
 function affwp_notify_on_new_referral( $affiliate_id = 0, $referral ) {
 
-	$user_id = affwp_get_affiliate_user_id( $affiliate_id );
+	$user_id                 = affwp_get_affiliate_user_id( $affiliate_id );
+	$notification_key_exists = metadata_exists( 'user', $user_id, 'affwp_referral_notifications' );
+	$referral_notifications  = $notification_key_exists ? get_user_meta( $user_id, 'affwp_referral_notifications', true ) : affiliate_wp()->settings->get( 'enable_default_new_referral_emails' );
 
-	if( ! get_user_meta( $user_id, 'affwp_referral_notifications', true ) ) {
+	if( ! $referral_notifications ) {
 		return;
 	}
 

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1215,3 +1215,29 @@ function affwp_required_field_attr( $field ) {
 
 	return $required;
 }
+
+/**
+ * Helper to unserialize values based on an object whitelist.
+ *
+ * @since 2.1.4.2
+ *
+ * @param string $original  Maybe unserialized original, if is needed.
+ * @return mixed Unserialized data can be any type.
+ */
+function affwp_maybe_unserialize( $original ) {
+	$value = $original;
+
+	if ( is_serialized( $original ) ) {
+
+		preg_match( '/[oO]\s*:\s*\d+\s*:\s*"\s*(?!(?i)(stdClass))/', $original, $matches );
+
+		if ( ! empty( $matches ) ) {
+			$value = '';
+		} else {
+			$value = maybe_unserialize( $original );
+		}
+	}
+
+	return $value;
+}
+

--- a/includes/referral-functions.php
+++ b/includes/referral-functions.php
@@ -22,10 +22,6 @@ function affwp_get_referral( $referral = null ) {
 		$referral->products = maybe_unserialize( maybe_unserialize( $referral->products ) );
 	}
 
-	if ( ! empty( $referral->custom ) ) {
-		$referral->custom = maybe_unserialize( maybe_unserialize( $referral->custom ) );
-	}
-
 	return $referral;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "AffiliateWP",
-	"version": "2.1.4.1",
+	"version": "2.1.4.2",
 	"description": "Affiliate Plugin for WordPress",
 	"homepage": "https://affiliatewp.com/",
 	"author": {

--- a/templates/dashboard-tab-settings.php
+++ b/templates/dashboard-tab-settings.php
@@ -1,8 +1,12 @@
 <?php
-$affiliate_id      = affwp_get_affiliate_id();
-$affiliate_user_id = affwp_get_affiliate_user_id( $affiliate_id );
-$user_email        = affwp_get_affiliate_email( $affiliate_id );
-$payment_email     = affwp_get_affiliate_payment_email( $affiliate_id, $user_email ); // Fallback to user_email
+$affiliate_id            = affwp_get_affiliate_id();
+$affiliate_user_id       = affwp_get_affiliate_user_id( $affiliate_id );
+$user_email              = affwp_get_affiliate_email( $affiliate_id );
+// Fallback to user_email
+$payment_email           = affwp_get_affiliate_payment_email( $affiliate_id, $user_email );
+// If the affwp_referral_notifications key exists, retrieve the meta value. Otherwise, referral notifications are determined from the global setting enable_default_new_referral_emails.
+$notification_key_exists = metadata_exists( 'user', $affiliate_user_id, 'affwp_referral_notifications' );
+$referral_notifications  = $notification_key_exists ? get_user_meta( $affiliate_user_id, 'affwp_referral_notifications', true ) : affiliate_wp()->settings->get( 'enable_default_new_referral_emails' );
 ?>
 
 <div id="affwp-affiliate-dashboard-profile" class="affwp-tab-content">
@@ -17,7 +21,7 @@ $payment_email     = affwp_get_affiliate_payment_email( $affiliate_id, $user_ema
 		</div>
 
 		<div class="affwp-wrap affwp-send-notifications-wrap">
-			<input id="affwp-referral-notifications" type="checkbox" name="referral_notifications" value="1" <?php checked( true, get_user_meta( $affiliate_user_id, 'affwp_referral_notifications', true ) ); ?>/>
+			<input id="affwp-referral-notifications" type="checkbox" name="referral_notifications" value="1" <?php checked( true, $referral_notifications ); ?>/>
 			<label for="affwp-referral-notifications"><?php _e( 'Enable New Referral Notifications', 'affiliate-wp' ); ?></label>
 		</div>
 

--- a/tests/affiliates/test-affiliate-functions.php
+++ b/tests/affiliates/test-affiliate-functions.php
@@ -1980,4 +1980,110 @@ class Tests extends UnitTestCase {
 			affwp_delete_payout( $payout );
 		}
 	}
+
+	/**
+	 * @covers ::affwp_get_affiliate_meta()
+	 */
+	public function test_get_affiliate_meta_single_should_return_single_value_only() {
+		affwp_add_affiliate_meta( self::$affiliates[0], 'foo', 'bar' );
+
+		$results = affwp_get_affiliate_meta( self::$affiliates[0], 'foo', true );
+
+		$this->assertSame( 'bar', $results );
+
+		// Clean up.
+		affwp_delete_affiliate_meta( self::$affiliates[0], 'foo', 'bar' );
+	}
+
+	/**
+	 * @covers ::affwp_get_affiliate_meta()
+	 */
+	public function test_get_affiliate_meta_not_single_should_return_all_values() {
+		$expected = array( 'bar', 'baz' );
+
+		affwp_add_affiliate_meta( self::$affiliates[0], 'foo', 'bar' );
+		affwp_add_affiliate_meta( self::$affiliates[0], 'foo', 'baz' );
+
+		$results = affwp_get_affiliate_meta( self::$affiliates[0], 'foo' );
+
+		$this->assertEqualSets( $expected, $results );
+
+		// Clean up.
+		affwp_delete_affiliate_meta( self::$affiliates[0], 'foo' );
+	}
+
+	/**
+	 * @covers ::affwp_get_affiliate_meta()
+	 */
+	public function test_get_affiliate_meta_single_with_serialized_stdClass_object_should_return_that_object() {
+		$object = new \stdClass();
+		$object->is_object = true;
+
+		affwp_add_affiliate_meta( self::$affiliates[1], 'objects', $object );
+
+		$results = affwp_get_affiliate_meta( self::$affiliates[1], 'objects', true );
+
+		$this->assertEquals( $object, $results );
+
+		// Clean up.
+		affwp_delete_affiliate_meta( self::$affiliates[1], 'objects' );
+	}
+
+	/**
+	 * @covers ::affwp_get_affiliate_meta()
+	 */
+	public function test_get_affiliate_meta_single_with_serialized_non_stdClass_object_should_return_empty_string() {
+		$referral = $this->factory->referral->create_and_get();
+
+		affwp_add_affiliate_meta( self::$affiliates[1], 'objects', $referral );
+
+		$results = affwp_get_affiliate_meta( self::$affiliates[1], 'objects', true );
+
+		$this->assertSame( '', $results );
+
+		// Clean up.
+		affwp_delete_affiliate_meta( self::$affiliates[1], 'objects' );
+	}
+
+	/**
+	 * @covers ::affwp_get_affiliate_meta()
+	 */
+	public function test_get_affiliate_meta_not_single_with_serialized_array_of_stdClass_objects_should_return_those_objects() {
+		$object1 = new \stdClass();
+		$object1->first = true;
+
+		$object2 = new \stdClass();
+		$object2->first = false;
+
+		$meta_value = array( $object1, $object2 );
+
+		affwp_add_affiliate_meta( self::$affiliates[1], 'objects', $meta_value );
+
+		$results = affwp_get_affiliate_meta( self::$affiliates[1], 'objects' );
+
+		$this->assertEqualSets( array( $meta_value ), $results );
+
+		// Clean up.
+		affwp_delete_affiliate_meta( self::$affiliates[1], 'objects' );
+	}
+
+	/**
+	 * @covers ::affwp_get_affiliate_meta()
+	 */
+	public function test_get_affiliate_meta_not_single_with_serialized_array_of_non_stdClass_objects_should_return_empty_array() {
+		$affiliate1 = $this->factory->affiliate->create_and_get();
+		$affiliate2 = $this->factory->affiliate->create_and_get();
+
+		$meta_value = array( $affiliate1, $affiliate2 );
+
+		affwp_add_affiliate_meta( self::$affiliates[1], 'objects', $meta_value );
+
+		$results = affwp_get_affiliate_meta( self::$affiliates[1], 'objects' );
+
+		$this->assertSame( array( '' ), $results );
+
+		// Clean up.
+		affwp_delete_affiliate_meta( self::$affiliates[1], 'objects' );
+	}
+
 }

--- a/tests/misc/test-misc-functions.php
+++ b/tests/misc/test-misc-functions.php
@@ -556,4 +556,39 @@ class Tests extends UnitTestCase {
 		) );
 	}
 
+	/**
+	 * @covers ::affwp_maybe_unserialize()
+	 */
+	public function test_maybe_unserialize_with_non_serialized_string_should_return_original() {
+		$result = affwp_maybe_unserialize( 'foo' );
+
+		$this->assertSame( 'foo', $result );
+	}
+
+	/**
+	 * @covers ::affwp_maybe_unserialize()
+	 */
+	public function test_maybe_unserialize_with_serialized_stdClass_object_should_return_that_object() {
+		$object = new \stdClass();
+		$object->is_stdClass = true;
+
+		$serialized_object = maybe_serialize( $object );
+
+		$result = affwp_maybe_unserialize( $serialized_object );
+
+		$this->assertEquals( $object, $result );
+	}
+
+	/**
+	 * @covers ::affwp_maybe_unserialize()
+	 */
+	public function test_maybe_unserialize_with_serialized_non_stdClass_object_should_return_empty_string() {
+		$affiliate = $this->factory->affiliate->create_and_get();
+		$serialized_affiliate = maybe_serialize( $affiliate );
+
+		$result = affwp_maybe_unserialize( $serialized_affiliate );
+
+		$this->assertSame( '', $result );
+	}
+
 }

--- a/tests/referrals/test-referral-functions.php
+++ b/tests/referrals/test-referral-functions.php
@@ -142,6 +142,72 @@ class Tests extends UnitTestCase {
 	}
 
 	/**
+	 * @covers ::affwp_get_referral()
+	 */
+	public function test_get_referral_with_non_whitelisted_class_serialized_in_custom_should_retrieve_empty_custom() {
+		$referral = $this->factory->referral->create_and_get( array(
+			'affiliate_id' => self::$_affiliate_id,
+			'custom'       => $this->factory->affiliate->create_and_get()
+		) );
+
+		$this->assertSame( '', $referral->custom );
+
+		// Clean up.
+		affwp_delete_referral( $referral );
+	}
+
+	/**
+	 * @covers ::affwp_get_referral()
+	 */
+	public function test_get_referral_with_array_non_whitelisted_custom_should_retrieve_empty_custom() {
+		$referral = $this->factory->referral->create_and_get( array(
+			'affiliate_id' => self::$_affiliate_id,
+			'custom'       => array( $this->factory->affiliate->create_and_get() )
+		) );
+
+		$this->assertSame( '', $referral->custom );
+
+		// Clean up.
+		affwp_delete_referral( $referral );
+	}
+
+	/**
+	 * @covers ::affwp_get_referral()
+	 */
+	public function test_get_referral_with_stdclass_custom_should_retrieve_the_serialized_object() {
+		$object = new \stdClass();
+		$object->foo = 'bar';
+
+		$referral = $this->factory->referral->create_and_get( array(
+			'affiliate_id' => self::$_affiliate_id,
+			'custom'       => $object,
+		) );
+
+		$this->assertEquals( $object, $referral->custom );
+
+		// Clean up.
+		affwp_delete_referral( $referral );
+	}
+
+	/**
+	 * @covers ::affwp_get_referral()
+	 */
+	public function test_get_referral_with_array_stdclass_custom_should_retrieve_the_serialized_object() {
+		$object = new \stdClass();
+		$object->foo = 'bar';
+
+		$referral = $this->factory->referral->create_and_get( array(
+			'affiliate_id' => self::$_affiliate_id,
+			'custom'       => array( $object ),
+		) );
+
+		$this->assertEquals( array( $object ), $referral->custom );
+
+		// Clean up.
+		affwp_delete_referral( $referral );
+	}
+
+	/**
 	 * @covers ::affwp_get_referral_status()
 	 */
 	public function test_get_referral_status_with_invalid_referral_id_should_return_false() {


### PR DESCRIPTION
- Adds global `enable_default_new_referral_emails `, which is used to determine whether new referral email notifications are sent, if the user doesn’t have an `affwp_referral_notifications` meta key already set.
- Adds related check in `affwp_notify_on_new_referral`
- #1960