### PR TITLE
Add option to set cookies for sub-domains

### DIFF
--- a/assets/js/tracking.js
+++ b/assets/js/tracking.js
@@ -368,12 +368,18 @@ jQuery(document).ready( function($) {
 	}
 
 	/**
-	 * Set a cookie, with optional domain if set.
+	 * Set a cookie, with optional domain if set. Note that providing *any* domain will
+	 * set the cookie domain with a leading dot, indicating it should be sent to sub-domains.
 	 *
-	 * @since
+	 * example: host.tld
 	 *
-	 * @param {string} name
-	 * @param {string} value
+	 * - $.cookie( 'some_cookie', ...) = cookie domain: host.tld
+	 * - $.cookie ('some_cookie', ... domain: 'host.tld' ) = .host.tld
+	 *
+	 * @since 2.x.x
+	 *
+	 * @param {string} name cookie name, e.g. affwp_ref
+	 * @param {string} value cookie value
 	 */
 	function affwp_set_cookie( name, value ) {
 

--- a/assets/js/tracking.js
+++ b/assets/js/tracking.js
@@ -341,7 +341,7 @@ jQuery(document).ready( function($) {
 	function affwp_track_visit( affiliate_id, url_campaign ) {
 
 		// Set the cookie and expire it after 24 hours
-		$.cookie( 'affwp_ref', affiliate_id, { expires: AFFWP.expiration, path: '/' } );
+		affwp_set_cookie( 'affwp_ref', affiliate_id );
 
 		// Fire an ajax request to log the hit
 		$.ajax({
@@ -355,8 +355,8 @@ jQuery(document).ready( function($) {
 			},
 			url: affwp_scripts.ajaxurl,
 			success: function (response) {
-				$.cookie( 'affwp_ref_visit_id', response, { expires: AFFWP.expiration, path: '/' } );
-				$.cookie( 'affwp_campaign', url_campaign, { expires: AFFWP.expiration, path: '/' } );
+				affwp_set_cookie( 'affwp_ref_visit_id', response );
+				affwp_set_cookie( 'affwp_campaign', url_campaign );
 			}
 
 		}).fail(function (response) {
@@ -365,6 +365,23 @@ jQuery(document).ready( function($) {
 			}
 		});
 
+	}
+
+	/**
+	 * Set a cookie, with optional domain if set.
+	 *
+	 * @since
+	 *
+	 * @param {string} name
+	 * @param {string} value
+	 */
+	function affwp_set_cookie( name, value ) {
+
+		if ( 'cookie_domain' in AFFWP ) {
+			$.cookie( name, value, { expires: AFFWP.expiration, path: '/', domain: AFFWP.cookie_domain } );
+		} else {
+			$.cookie( name, value, { expires: AFFWP.expiration, path: '/' } );
+		}
 	}
 
 	/**

--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -544,6 +544,11 @@ class Affiliate_WP_Settings {
 						'size' => 'small',
 						'std' => '1'
 					),
+					'cookie_sharing' => array(
+						'name' => __( 'Cookie Sharing', 'affiliate-wp' ),
+						'desc' => __( 'Share tracking cookies with sub-domains.', 'affiliate-wp' ),
+						'type' => 'checkbox',
+					),
 					'currency_settings' => array(
 						'name' => '<strong>' . __( 'Currency Settings', 'affiliate-wp' ) . '</strong>',
 						'desc' => __( 'Configure the currency options', 'affiliate-wp' ),

--- a/includes/class-tracking.php
+++ b/includes/class-tracking.php
@@ -112,6 +112,10 @@ class Affiliate_WP_Tracking {
 		AFFWP.expiration = <?php echo $this->get_expiration_time(); ?>;
 		AFFWP.debug = <?php echo absint( $this->debug ); ?>;
 
+<?php if ( $cookie_domain = $this->get_cookie_domain() ) : ?>
+		AFFWP.cookie_domain = '<?php echo esc_js( $cookie_domain ); ?>';
+<?php endif; ?>
+
 <?php if( 1 !== (int) get_option( 'affwp_js_works' ) )  : ?>
 		jQuery(document).ready(function($) {
 			// Check if JS is working properly. If it is, we update an update in the DB
@@ -664,7 +668,7 @@ class Affiliate_WP_Tracking {
 	 * @since 1.0
 	 */
 	public function set_visit_id( $visit_id = 0 ) {
-		setcookie( 'affwp_ref_visit_id', $visit_id, strtotime( '+' . $this->get_expiration_time() . ' days' ), COOKIEPATH, COOKIE_DOMAIN );
+		setcookie( 'affwp_ref_visit_id', $visit_id, strtotime( '+' . $this->get_expiration_time() . ' days' ), COOKIEPATH, $this->get_cookie_domain() );
 	}
 
 	/**
@@ -747,7 +751,23 @@ class Affiliate_WP_Tracking {
 	 * @since 1.0
 	 */
 	public function set_affiliate_id( $affiliate_id = 0 ) {
-		setcookie( 'affwp_ref', $affiliate_id, strtotime( '+' . $this->get_expiration_time() . ' days' ), COOKIEPATH, COOKIE_DOMAIN );
+		setcookie( 'affwp_ref', $affiliate_id, strtotime( '+' . $this->get_expiration_time() . ' days' ), COOKIEPATH, $this->get_cookie_domain() );
+	}
+
+	/**
+	 * Get the cookie domain
+	 * @return bool|string
+	 */
+	public function get_cookie_domain() {
+
+		// COOKIE_DOMAIN is false by default
+		$cookie_domain = COOKIE_DOMAIN;
+
+		if ( ! $cookie_domain && affiliate_wp()->settings->get( 'cookie_sharing', false ) ) {
+			$cookie_domain = parse_url( get_home_url(), PHP_URL_HOST );
+		}
+
+		return apply_filters( 'affwp_tracking_cookie_domain', $cookie_domain );
 	}
 
 	/**

--- a/includes/class-tracking.php
+++ b/includes/class-tracking.php
@@ -755,18 +755,30 @@ class Affiliate_WP_Tracking {
 	}
 
 	/**
-	 * Get the cookie domain
-	 * @return bool|string
+	 * Get the cookie domain.
+	 *
+	 * @return bool|string false if a cookie domain isn't set, string hostname (host.tld) otherwise
 	 */
 	public function get_cookie_domain() {
 
 		// COOKIE_DOMAIN is false by default
 		$cookie_domain = COOKIE_DOMAIN;
 
-		if ( ! $cookie_domain && affiliate_wp()->settings->get( 'cookie_sharing', false ) ) {
+		$share_cookies = affiliate_wp()->settings->get( 'cookie_sharing', false );
+
+		// providing a domain to jQuery.cookie or PHP's setcookie results prefixes the cookie domain
+		// with a dot, indicating it should be shared with sub-domains
+		if ( ! $cookie_domain && $share_cookies ) {
 			$cookie_domain = parse_url( get_home_url(), PHP_URL_HOST );
 		}
 
+		/**
+		 * Filters the tracking cookie domain.
+		 *
+		 * @since 2.x.x
+		 *
+		 * @param string $cookie_domain cookie domain
+		 */
 		return apply_filters( 'affwp_tracking_cookie_domain', $cookie_domain );
 	}
 


### PR DESCRIPTION
This PR expands on #2140/#2142 to:

- add a setting to allow sharing tracking cookies with sub-domains (disabled by default)
<img width="710" alt="screen shot 2017-09-13 at 4 59 38 pm" src="https://user-images.githubusercontent.com/1579862/30400595-5bea4a66-98a5-11e7-8e4b-d181757e1c2e.png">


- automatically use the WP `COOKIE_DOMAIN` constant, if set

This could be considered a breaking change since previously the `COOKIE_DOMAIN` was only used for fallback (server-side) tracking, but not JS tracking.