### PR TITLE
Fix warning for wp_upload_dir() on read-only filesystems

### DIFF
--- a/includes/class-logging.php
+++ b/includes/class-logging.php
@@ -25,7 +25,7 @@ class Affiliate_WP_Logging {
 	 */
 	public function init() {
 
-		$upload_dir       = wp_upload_dir();
+		$upload_dir       = wp_upload_dir( null, false );
 		$this->filename   = 'affwp-debug.log';
 		$this->file       = trailingslashit( $upload_dir['basedir'] ) . $this->filename;
 


### PR DESCRIPTION
This PR fixes an issue where `wp_upload_dir()` will generate the warning bellow on a read-only filesystem:

```
[03-Oct-2017 07:50:20 UTC]
[Suppressed] Warning: mkdir(): Read-only file system in /var/www/wp-includes/functions.php on line 1624
[wp-includes/functions.php:1624 mkdir(), wp-includes/functions.php:1888 wp_mkdir_p(), wp-content/plugins/affiliate-wp/includes/class-logging.php:28 wp_upload_dir(), wp-content/plugins/affiliate-wp/includes/class-logging.php:16 init(), wp-content/plugins/affiliate-wp/includes/class-utilities.php:91 __construct(), wp-content/plugins/affiliate-wp/includes/class-utilities.php:64 setup_objects(), wp-content/plugins/affiliate-wp/affiliate-wp.php:479 __construct(), wp-includes/class-wp-hook.php:298 setup_objects(), wp-includes/class-wp-hook.php:323 apply_filters(''), wp-includes/plugin.php:453 do_action('Array'), wp-settings.php:325 do_action('plugins_loaded'), wp-config.php:14 require_once('wp-settings.php'), wp-load.php:37 require_once('wp-config.php'), wp-blog-header.php:13 require_once('wp-load.php'), index.php:17 require('wp-blog-header.php')]
```

By default `wp_upload_dir()` will try to create the folder if it does not exist and this is a problem on a read-only filesystem. I haven't checked AffiliateWP code thoroughly, but I'm assuming that it simply wants the location of the upload dir so it should be safe to pass false to the `wp_upload_dir()` create param to avoid the warning.

This PR was created using GitHub file editor. I haven't tested this code.