### PR TITLE
Fix issue with submitting forms without the "action" attribute

### DIFF
--- a/includes/integrations/class-paypal.php
+++ b/includes/integrations/class-paypal.php
@@ -44,7 +44,7 @@ class Affiliate_WP_PayPal extends Affiliate_WP_Base {
 				var action = $(this).attr( 'action' );
 
 				// Bail if there's no action attribute on the form tag.
-				if ( 'undefined' === action ) {
+				if ( 'undefined' === typeof action ) {
 					return;
 				}
 


### PR DESCRIPTION
There's a typo when checking if the "action" attr is present in the form element
instead of `if ( 'undefined' === typeof action )`
it's `if ( 'undefined' === action )`

This breaks forms without an action, as it throws an error later when trying to match `action.match( paypalMatch )`

<!--- Please prefix your PR description above with the issue number: issue/### – PR Description -->

Issue: #2527