### PR TITLE
Issue/2632 - Fix SQL error when using the campaign keyword prefix to search on the Visits page

### DIFF
--- a/includes/class-visits-db.php
+++ b/includes/class-visits-db.php
@@ -237,7 +237,7 @@ class Affiliate_WP_Visits_DB extends Affiliate_WP_DB {
 				if ( empty( $args['campaign'] ) ) {
 					$where .= "`campaign` {$campaign_compare} '' ";
 				} else {
-					$where .= "`campaign` {$campaign_compare} {$args['campaign']} ";
+					$where .= "`campaign` {$campaign_compare} '{$args['campaign']}' ";
 				}
 			}
 


### PR DESCRIPTION
Issue: #2632 