### PR TITLE
Issue/2695 - Only add password reset link to acceptance email when password field isn't required during registration

### DIFF
--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -145,7 +145,7 @@ function affwp_notify_on_approval( $affiliate_id = 0, $status = '', $old_status 
 
 	$required_registration_fields = affiliate_wp()->settings->get( 'required_registration_fields' );
 
-	if ( ! is_wp_error( $key ) && ( empty( $_POST['user_email'] ) || ! isset( $required_registration_fields['password'] ) ) ) {
+	if ( ! is_wp_error( $key ) && ! isset( $required_registration_fields['password'] ) ) {
 		$message .= "\r\n\r\n" . __( 'To set your password, visit the following address:', 'affiliate-wp' ) . "\r\n\r\n";
 		$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . "\r\n";
 	}


### PR DESCRIPTION
Issue: #2695 