### PR TITLE
Issue/2726 - Always use the default text in the text_callback() method in the Affiliate_WP_Settings class if the text field is empty.

### DIFF
--- a/includes/admin/settings/class-settings.php
+++ b/includes/admin/settings/class-settings.php
@@ -1099,7 +1099,7 @@ class Affiliate_WP_Settings {
 	 */
 	function text_callback( $args ) {
 
-		if ( isset( $this->options[ $args['id'] ] ) )
+		if ( isset( $this->options[ $args['id'] ] ) && ! empty( $this->options[ $args['id'] ] ) )
 			$value = $this->options[ $args['id'] ];
 		else
 			$value = isset( $args['std'] ) ? $args['std'] : '';


### PR DESCRIPTION
Issue: #2726