### PR TITLE
Issue/2692 - Fix description not set for referrals generated through WP Simple Pay

### DIFF
--- a/includes/integrations/class-stripe.php
+++ b/includes/integrations/class-stripe.php
@@ -30,6 +30,8 @@ class Affiliate_WP_Stripe extends Affiliate_WP_Base {
 
 		if( $this->was_referred() ) {
 
+			global $simpay_form;
+
 			switch( $object->object ) {
 
 				case 'subscription' :
@@ -38,7 +40,7 @@ class Affiliate_WP_Stripe extends Affiliate_WP_Base {
 
 					$stripe_amount = ! empty( $object->plan->trial_period_days ) ? 0 : $object->plan->amount;
 					$currency      = $object->plan->currency;
-					$description   = $object->plan->name;
+					$description   = $object->plan->nickname;
 					$mode          = $object->plan->livemode;
 
 					break;
@@ -62,6 +64,12 @@ class Affiliate_WP_Stripe extends Affiliate_WP_Base {
 					$mode          = $object->livemode;
 
 					break;
+
+			}
+
+			if ( empty( $description ) && isset( $simpay_form->post->post_title ) ) {
+
+				$description = $simpay_form->post->post_title;
 
 			}
 


### PR DESCRIPTION
Issue: #2692